### PR TITLE
Add GitLab Helm chart repo to list of distributed repositories.

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -20,3 +20,5 @@ sync:
       url: https://charts.keel.sh
     - name: appscode
       url: https://charts.appscode.com/stable/
+    - name: gitlab
+      url: https://charts.gitlab.io/

--- a/repos.yaml
+++ b/repos.yaml
@@ -48,3 +48,8 @@ repositories:
   maintainers:
     - name: AppsCode Inc
       email: support@appscode.com
+- name: gitlab
+  url: https://charts.gitlab.io/
+  maintainers:
+    - name: GitLab
+      email: distribution@gitlab.com


### PR DESCRIPTION
This PR adds the GitLab helm chart repository to the list of distributed repositories.