### PR TITLE
add bitnami chart repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -22,3 +22,5 @@ sync:
       url: https://charts.appscode.com/stable/
     - name: gitlab
       url: https://charts.gitlab.io/
+    - name: bitnami
+      url: https://charts.bitnami.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -53,3 +53,8 @@ repositories:
   maintainers:
     - name: GitLab
       email: distribution@gitlab.com
+- name: bitnami
+  url: https://charts.bitnami.com
+  maintainers:
+    - name: Bitnami
+      email: containers@bitnami.com


### PR DESCRIPTION
Adds the Bitnami Charts repository (https://github.com/bitnami/charts)
to the Helm Hub.

Note that this repository contains some charts mirrored (they hold the
exact same digest) in the Helm stable repository, [this
change](https://github.com/helm/monocular/pull/571) in Monocular handles
filtering out duplicate charts so they will not show in the list of
charts. The logic will currently show the chart from the first
repository it finds it in (i.e. it will pick whichever repository was
synced first).

Once the Bitnami charts are deprecated in the Helm stable repository,
this repository will automatically take preference and the duplicate
charts from stable will no longer be shown.