### PR TITLE
Add Weave Flux chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -24,3 +24,5 @@ sync:
       url: https://charts.gitlab.io/
     - name: bitnami
       url: https://charts.bitnami.com
+    - name: weave-flux
+      url: https://weaveworks.github.io/flux/

--- a/repos.yaml
+++ b/repos.yaml
@@ -58,3 +58,8 @@ repositories:
   maintainers:
     - name: Bitnami
       email: containers@bitnami.com
+- name: weave-flux
+  url: https://weaveworks.github.io/flux/
+  maintainers:
+    - email: flux@weave.works
+      name: Weave Flux project


### PR DESCRIPTION
These commits add an entry each to `config/repo-values.yaml` and `repos.yaml`, for the chart repo maintained for the Weave Flux project.
