### PR TITLE
Add Jetstack helm chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -26,3 +26,5 @@ sync:
       url: https://charts.bitnami.com
     - name: weave-flux
       url: https://weaveworks.github.io/flux/
+    - name: jetstack
+      url: https://charts.jetstack.io

--- a/repos.yaml
+++ b/repos.yaml
@@ -63,3 +63,10 @@ repositories:
   maintainers:
     - email: flux@weave.works
       name: Weave Flux project
+- name: jetstack
+  url: https://charts.jetstack.io/
+  maintainers:
+    - email: james.munnelly@jetstack.io
+      name: James Munnelly
+    - email: christian.simon@jetstack.io
+      name: Christian Simon


### PR DESCRIPTION
Hey :wave:

Great work getting the hub up and running! 😄 

We've got chartmuseum up and running within Jetstack, and will be using it for publishing and distributing cert-manager and our other charts.

Look forward to seeing this delegated chart repo model thrive!!

/cc @rimusz @simonswine