### PR TITLE
Adding IBM Cloud Private Helm Chart Repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -26,3 +26,5 @@ sync:
       url: https://charts.bitnami.com
     - name: weave-flux
       url: https://weaveworks.github.io/flux/
+    - name: ibm-charts
+      url: https://raw.githubusercontent.com/IBM/charts/master/repo/stable/

--- a/repos.yaml
+++ b/repos.yaml
@@ -63,3 +63,8 @@ repositories:
   maintainers:
     - email: flux@weave.works
       name: Weave Flux project
+- name: ibm-charts
+  url: https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+  maintainers:
+    - email: icp@ibm.com
+      name: IBM Cloud Private


### PR DESCRIPTION
The IBM/charts repository provides helm charts for IBM and Third Party middleware.