### PR TITLE
feat(repos.yaml): add hephy workflow charts

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -44,3 +44,5 @@ sync:
       url: https://kiwigrid.github.io
     - name: elastic
       url: https://helm.elastic.co
+    - name: hephy
+      url: https://charts.teamhephy.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -112,3 +112,8 @@ repositories:
   maintainers:
   - email: helm-charts@elastic.co
     name: Elastic
+- name: hephy
+  url: https://charts.teamhephy.com
+  maintainers:
+  - name: Team Hephy
+    email: team@teamhephy.com


### PR DESCRIPTION
Maintainer of Hephy Workflow charts (https://github.com/teamhephy) here. We would like to be a part of the Helm Hub. Our main charts repo is `charts.teamhephy.com` .