### PR TITLE
Added odavid repo currently hosting my-bloody-jenkins helm chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -46,3 +46,5 @@ sync:
       url: https://helm.elastic.co
     - name: openfaas
       url: https://openfaas.github.io/faas-netes/index.yaml
+    - name: odavid
+      url: https://odavid.github.io/k8s-helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -121,3 +121,8 @@ repositories:
       name: Lucas Roesler
     - email: stefan.prodan@gmail.com
       name: Stefan Prodan
+- name: odavid
+  url: https://odavid.github.io/k8s-helm-charts
+  maintainers:
+    - email: ohad.david@gmail.com
+      name: Ohad David


### PR DESCRIPTION
[my-bloody-jenkins](https://github.com/odavid/my-bloody-jenkins) is an opinionated, self configured Jenkins Docker image based on Jenkins-LTS. Will be glad if it can be added to helm hub.

Regards,
Ohad
 