### PR TITLE
Add Ceph CSI driver repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -60,3 +60,5 @@ sync:
       url: https://eventstore.github.io/EventStore.Charts
     - name: pnnl-miscscripts
       url: https://pnnl-miscscripts.github.io/charts
+    - name: ceph-csi
+      url: https://ceph.github.io/csi-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -162,3 +162,7 @@ repositories:
   maintainers:
     - email: Kevin.Fox@pnnl.gov
       name: Kevin Fox
+- name: ceph-csi
+  url: https://ceph.github.io/csi-charts
+  maintainers:
+    - email: ceph-devel@vger.kernel.org


### PR DESCRIPTION
This adds support for the Ceph CSI helm chart repository
enabling easy deployment of Ceph support to Kubernetes.