### PR TITLE
Adding citrix ingress controller chart repo information

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -70,3 +70,5 @@ sync:
       url: https://hazelcast.github.io/charts/
     - name: nginx
       url: https://helm.nginx.com/stable
+    - name: cic
+      url: https://citrix.github.io/citrix-k8s-ingress-controller/

--- a/repos.yaml
+++ b/repos.yaml
@@ -185,3 +185,8 @@ repositories:
   url: https://helm.nginx.com/stable
   maintainers:
     - email: kubernetes@nginx.com
+- name: cic
+  url: https://citrix.github.io/citrix-k8s-ingress-controller/
+  maintainers:
+    - email: priyanka.sharma@citrix.com
+    - email: subash.dangol@citrix.com


### PR DESCRIPTION
Adding the required chart repo information as per the guidelines are given in https://github.com/helm/hub/blob/master/Repositories.md.