### PR TITLE
banzaicloud-stable: change base URL

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -39,7 +39,7 @@ sync:
     - name: agones
       url: https://agones.dev/chart/stable
     - name: banzaicloud-stable
-      url: http://kubernetes-charts.banzaicloud.com/branch/master
+      url: https://kubernetes-charts.banzaicloud.com
     - name: kiwigrid
       url: https://kiwigrid.github.io
     - name: elastic

--- a/repos.yaml
+++ b/repos.yaml
@@ -96,7 +96,7 @@ repositories:
   - email: agones-discuss@googlegroups.com
     name: agones
 - name: banzaicloud-stable
-  url: http://kubernetes-charts.banzaicloud.com/branch/master
+  url: https://kubernetes-charts.banzaicloud.com
   maintainers:
   - name: Banzai Cloud
     email: info@banzaicloud.com


### PR DESCRIPTION
We have migrated our helm repository to a new backend and place. While the change is backward compatible, the new url is preferred.