### PR TITLE
Add mmlspark spark 2.4 repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -78,3 +78,6 @@ sync:
       url : https://releases.rancher.com/server-charts/stable
     - name: loki
       url: https://grafana.github.io/loki/charts
+    - name: mmlspark
+      url: https://dbanda.github.io/charts
+      

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -78,5 +78,5 @@ sync:
       url : https://releases.rancher.com/server-charts/stable
     - name: loki
       url: https://grafana.github.io/loki/charts
-    - name: microsoft-charts
+    - name: microsoft
       url: http://microsoft.github.io/charts/repo

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -78,6 +78,6 @@ sync:
       url : https://releases.rancher.com/server-charts/stable
     - name: loki
       url: https://grafana.github.io/loki/charts
-    - name: mmlspark
-      url: https://dbanda.github.io/charts
+    - name: msft-charts
+      url: http://microsoft.github.io/charts/repo
       

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -78,6 +78,5 @@ sync:
       url : https://releases.rancher.com/server-charts/stable
     - name: loki
       url: https://grafana.github.io/loki/charts
-    - name: msft-charts
+    - name: microsoft-charts
       url: http://microsoft.github.io/charts/repo
-      

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -79,7 +79,7 @@ sync:
     - name: loki
       url: https://grafana.github.io/loki/charts
     - name: microsoft
-      url: http://microsoft.github.io/charts/repo
+      url: https://microsoft.github.io/charts/repo
     - name: codecentric
       url: https://codecentric.github.io/helm-charts
     - name: okgolove

--- a/repos.yaml
+++ b/repos.yaml
@@ -203,3 +203,10 @@ repositories:
   maintainers:
   - name: Loki Maintainers
     mail: lokiproject@googlegroups.com
+- name: mmlspark
+  url:
+  maintainers:
+  - name: Dalitso Banda
+    mail: dalitsohb@gmail.com
+  - name: Mark Hamilton
+    mail: mhamilton723@gmail.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -204,7 +204,7 @@ repositories:
   - name: Loki Maintainers
     mail: lokiproject@googlegroups.com
 - name: mmlspark
-  url: https://dbanda.github.io/charts
+  url: http://microsoft.github.io/charts/repo/
   maintainers:
-   - name: mmlspark
+   - name: mstf-charts
      email: mmlspark-support@microsoft.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -203,7 +203,7 @@ repositories:
   maintainers:
   - name: Loki Maintainers
     mail: lokiproject@googlegroups.com
-- name: microsoft-charts
+- name: microsoft
   url: http://microsoft.github.io/charts/repo/
   maintainers:
   - name: mstf-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -203,8 +203,9 @@ repositories:
   maintainers:
   - name: Loki Maintainers
     mail: lokiproject@googlegroups.com
-- name: mmlspark
+- name: microsoft-charts
   url: http://microsoft.github.io/charts/repo/
   maintainers:
-   - name: mstf-charts
-     email: mmlspark-support@microsoft.com
+  - name: mstf-charts
+    email: msft-charts-support@microsoft.com
+  - email: dabanda@microsoft.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -204,9 +204,7 @@ repositories:
   - name: Loki Maintainers
     mail: lokiproject@googlegroups.com
 - name: mmlspark
-  url:
+  url: https://dbanda.github.io/charts
   maintainers:
-  - name: Dalitso Banda
-    mail: dalitsohb@gmail.com
-  - name: Mark Hamilton
-    mail: mhamilton723@gmail.com
+   - name: mmlspark
+     email: mmlspark-support@microsoft.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -209,7 +209,7 @@ repositories:
       - name: Loki Maintainers
         email: lokiproject@googlegroups.com
   - name: microsoft
-    url: http://microsoft.github.io/charts/repo/
+    url: https://microsoft.github.io/charts/repo/
     maintainers:
       - name: mstf-charts
         email: msft-charts-support@microsoft.com


### PR DESCRIPTION
I am part of the team working on mmlspark https://github.com/Azure/mmlspark
In this PR we are submitting a repo that will house the helm chark for spark that we use for our project. The chart in this repo is an upgrade to stable/spark that supports the latest spark 2.4.0, Zeppelin 0.9 and Livy on kubernetes