### PR TITLE
Add emberstack repository.

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -80,3 +80,5 @@ sync:
       url: https://grafana.github.io/loki/charts
     - name: codecentric
       url: https://codecentric.github.io/helm-charts
+    - name: emberstack
+      url: https://emberstack.github.io/helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -212,3 +212,8 @@ repositories:
     url: https://codecentric.github.io/helm-charts
     maintainers:
       - email: unguiculus+helm-charts@gmail.com
+  - name: emberstack
+    url: https://emberstack.github.io/helm-charts
+    maintainers:
+      - email: helm-charts@emberstack.com
+        name: Romeo Dumitrescu


### PR DESCRIPTION
Submitting emberstack helm charts repo to the hub (as an alternative to the mono chart PR process as discussed with @scottrigby on https://github.com/helm/charts/pull/13351 ).