### PR TITLE
Added kafka-topics-ui chart repo ♣️

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -80,3 +80,5 @@ sync:
       url: https://grafana.github.io/loki/charts
     - name: codecentric
       url: https://codecentric.github.io/helm-charts
+    - name: dhiatn
+      url: https://dhiatn.github.io/helm-kafka-topics-ui

--- a/repos.yaml
+++ b/repos.yaml
@@ -212,3 +212,7 @@ repositories:
     url: https://codecentric.github.io/helm-charts
     maintainers:
       - email: unguiculus+helm-charts@gmail.com
+  - name: dhiatn
+    url: https://dhiatn.github.io/helm-kafka-topics-ui
+    maintainers:
+      - email: dhia.absi+helm@gmail.com


### PR DESCRIPTION
PR to add a [chart repo](https://dhiatn.github.io/helm-kafka-topics-ui) to helm hub.