### PR TITLE
Add Funky Penguin chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -80,3 +80,5 @@ sync:
       url: https://grafana.github.io/loki/charts
     - name: codecentric
       url: https://codecentric.github.io/helm-charts
+    - name: funkypenguin
+      url: https://funkypenguin.github.io/helm-charts      

--- a/repos.yaml
+++ b/repos.yaml
@@ -212,3 +212,7 @@ repositories:
     url: https://codecentric.github.io/helm-charts
     maintainers:
       - email: unguiculus+helm-charts@gmail.com
+  - name: funkypenguin
+    url: https://funkypenguin.github.io/helm-charts
+    maintainers:
+      - email: helm-charts@funkypenguin.co.nz      


### PR DESCRIPTION
I hope I'm following the instructions correctly. This PR adds https://funkypenguin.github.io/helm-charts/ to hub.helm.sh