### PR TITLE
Add APPUiO repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -87,8 +87,10 @@ sync:
     - name: k8dash
       url: https://herbrandson.github.io/k8dash/helm
     - name: funkypenguin
-      url: https://funkypenguin.github.io/helm-charts      
+      url: https://funkypenguin.github.io/helm-charts
     - name: mattermost
       url: https://helm.mattermost.com
     - name: emberstack
       url: https://emberstack.github.io/helm-charts
+    - name: APPUiO
+      url: https://charts.appuio.ch

--- a/repos.yaml
+++ b/repos.yaml
@@ -237,3 +237,8 @@ repositories:
     maintainers:
       - email: helm-charts@emberstack.com
         name: Romeo Dumitrescu
+- name: APPUiO
+    url: https://charts.appuio.ch
+    maintainers:
+      - email: info@appuio.ch
+        name: APPUiO Team


### PR DESCRIPTION
Helm chart repository used at VSHN [1] and APPUiO [2].

[1] https://vshn.ch/
[2] https://appuio.ch/