### PR TITLE
All config names need to be lowercase for the current chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -92,7 +92,10 @@ sync:
       url: https://helm.mattermost.com
     - name: emberstack
       url: https://emberstack.github.io/helm-charts
-    - name: APPUiO
+    # - name: APPUiO
+    # Switching to a lowercase name until https://github.com/helm/monocular/issues/626
+    # is fixed
+    - name: appuio
       url: https://charts.appuio.ch
     - name: gomods
       url: https://athens.blob.core.windows.net/charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -237,7 +237,10 @@ repositories:
     maintainers:
       - email: helm-charts@emberstack.com
         name: Romeo Dumitrescu
-  - name: APPUiO
+  # - name: APPUiO
+  # Switching to a lowercase name until https://github.com/helm/monocular/issues/626
+  # is fixed
+  - name: appuio
     url: https://charts.appuio.ch
     maintainers:
       - email: info@appuio.ch


### PR DESCRIPTION
The current chart will fail if the names contain uppercase letters.
Updating until monocular can be fixed.