### PR TITLE
Add charts.zentainer.app to repos

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -99,3 +99,5 @@ sync:
       url: https://charts.appuio.ch
     - name: gomods
       url: https://athens.blob.core.windows.net/charts
+    - name: zentainer
+      url: https://charts.zentainer.app

--- a/repos.yaml
+++ b/repos.yaml
@@ -250,4 +250,8 @@ repositories:
     maintainers:
       - email: aaron@ecomaz.net
         name: Aaron Schlesinger
-
+  - name: zentainer
+    url: https://charts.zenatiner.app
+    maintainers:
+      - name: Will Newby
+        email: will@zentainer.app


### PR DESCRIPTION
Adds the Zentainer charts repo, with Metacontroller chart, in reference to https://github.com/helm/charts/pull/8591