### PR TITLE
Add Promitor Helm repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -99,3 +99,5 @@ sync:
       url: https://charts.appuio.ch
     - name: gomods
       url: https://athens.blob.core.windows.net/charts
+    - name: promitor
+      url: https://promitor.azurecr.io/helm/v1/repo

--- a/repos.yaml
+++ b/repos.yaml
@@ -250,4 +250,9 @@ repositories:
     maintainers:
       - email: aaron@ecomaz.net
         name: Aaron Schlesinger
+  - name: promitor
+    url: https://promitor.azurecr.io/helm/v1/repo
+    maintainers:
+      - email: kerkhove.tom@gmail.com
+        name: Tom Kerkhove
 


### PR DESCRIPTION
Add Promitor Helm repo which is running on Azure Container Registry.

Installation documentation can be found on https://promitor.io/deployment/#kubernetes in case you want to give it a try