### PR TITLE
Add kir4h repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -105,3 +105,5 @@ sync:
       url: https://charts.zentainer.app
     - name: promitor
       url: https://promitor.azurecr.io/helm/v1/repo
+    - name: kir4h
+      url: https://kir4h.github.io/charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -270,7 +270,7 @@ repositories:
     url: https://kir4h.github.io/charts
     maintainers:
       - name: Andres Alvarez 
-        email: 1671935+kir4h@users.noreply.github.com
+        email: kir4h.gh@gmail.com
   - name: mtls
     url: https://drgrove.github.io/charts
     maintainers:

--- a/repos.yaml
+++ b/repos.yaml
@@ -266,3 +266,9 @@ repositories:
     maintainers:
       - email: kerkhove.tom@gmail.com
         name: Tom Kerkhove
+  - name: kir4h
+    url: https://kir4h.github.io/charts
+    maintainers:
+      - name: Andres Alvarez 
+        email: 1671935+kir4h@users.noreply.github.com
+


### PR DESCRIPTION
Signed-off-by: Andres Alvarez <1671935+kir4h@users.noreply.github.com>

The motivation for this PR is to make a chart available for registry-creds. 

Originally I submitted a [PR](https://github.com/helm/charts/pull/13660) to helm/charts/incubator, but on that thread @maorfr  suggested to host the chart instead.

Any feedback is welcome as this is my first chart and also my first approach to hosting a helm repository. 