### PR TITLE
Add Kubernetes-based Event Driven Autoscaling (KEDA)

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -115,3 +115,5 @@ sync:
       url: https://appdynamics.github.io/appdynamics-charts
     - name: billimek
       url: https://billimek.com/billimek-charts/
+    - name: kedacore
+      url: https://kedacore.azureedge.net/helm

--- a/repos.yaml
+++ b/repos.yaml
@@ -293,3 +293,8 @@ repositories:
     maintainers:
       - email: jeff@billimek.com
         name: Jeff Billimek
+  - name: kedacore
+    url: https://kedacore.azureedge.net/helm
+    maintainers:
+      - email: ahmels@microsoft.com
+        name: Ahmed ElSayed


### PR DESCRIPTION
Add Kubernetes-based Event Driven Autoscaling (KEDA) as Helm repo

Closes kedacore/keda#203