### PR TITLE
add seldon charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -121,3 +121,5 @@ sync:
       url: https://billimek.com/billimek-charts/
     - name: kedacore
       url: https://kedacore.azureedge.net/helm
+    - name: seldon
+      url: https://storage.googleapis.com/seldon-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -310,3 +310,12 @@ repositories:
     maintainers:
       - email: ahmels@microsoft.com
         name: Ahmed ElSayed
+  - name: seldon
+    url: https://storage.googleapis.com/seldon-charts
+    maintainers:
+      - email: cc@seldon.io
+        name: Clive Cox
+      - email: gs@seldon.io
+        name: Gurminder Sunner
+      - email: rd@seldon.io
+        name: Ryan Dawson


### PR DESCRIPTION
Seldon Core is an open source platform for deploying machine learning models on a Kubernetes cluster. Charts source at https://github.com/SeldonIO/seldon-core/tree/master/helm-charts