### PR TITLE
add PrivateBin to the helm hub

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -127,3 +127,5 @@ sync:
       url: https://gkarthiks.github.io/helm-charts
     - name: opsdroid
       url: https://helm.opsdroid.dev/
+    - name: privatebin
+      url: https://privatebin.github.io/helm-chart/

--- a/repos.yaml
+++ b/repos.yaml
@@ -325,3 +325,8 @@ repositories:
     maintainers:
       - email: jacob@tomlinson.email
         name: Jacob Tomlinson
+  - name: privatebin
+    url: https://privatebin.github.io/helm-chart/
+    maintainers:
+      - email: support@privatebin.org
+        name: PrivateBin maintainers


### PR DESCRIPTION
Adding the helm chart repo for [PrivateBin](https://privatebin.info/), an open source pastebin where the server has zero knowledge of pasted data.