### PR TITLE
Add g-research charts to the repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -129,3 +129,5 @@ sync:
       url: https://helm.opsdroid.dev/
     - name: privatebin
       url: https://privatebin.github.io/helm-chart/
+    - name: gresearch
+      url: https://g-research.github.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -330,3 +330,8 @@ repositories:
     maintainers:
       - email: support@privatebin.org
         name: PrivateBin maintainers
+  - name: gresearch
+    url: https://g-research.github.io/charts/
+    maintainers:
+      - email: g.research.oss@gmail.com
+        name: G-Research Open Source Developers


### PR DESCRIPTION
A helm chart for Apache storm is provided in our charts repo.

Signed-off-by: James Kirsch <g.research.oss@gmail.com>