### PR TITLE
Add smallstep repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -133,3 +133,5 @@ sync:
       url: https://privatebin.github.io/helm-chart/
     - name: gresearch
       url: https://g-research.github.io/charts/
+    - name: smallstep
+      url: https://smallstep.github.io/helm-charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -344,3 +344,8 @@ repositories:
     maintainers:
       - email: g.research.oss@gmail.com
         name: G-Research Open Source Developers
+  - name: smallstep
+    url: https://smallstep.github.io/helm-charts/
+    mainteiners:
+      - email: techadmin@smallstep.com
+        name: Smallstep Open Source Developers


### PR DESCRIPTION
## Description

This PR adds a smallstep repo to the Helm hub. At this moment smallstep repo provides to 
* Step Certificates: An online certificate authority and related tools for secure automated certificate management, so you can use TLS everywhere.
* Autocert: A kubernetes add-on that automatically injects TLS/HTTPS certificates into your containers.