### PR TITLE
add cetic helm charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -139,3 +139,5 @@ sync:
       url: https://volcano-sh.github.io/charts/
     - name: smallstep
       url: https://k8s.ory.sh/helm/charts
+    - name: cetic
+      url: https://cetic.github.io/helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -361,3 +361,10 @@ repositories:
     maintainers:
       - name: ORY Maintainers
         email: hi@ory.sh
+  - name: cetic
+    url: https://cetic.github.io/helm-charts
+    maintainers:
+      - email: alexandre.nuttinck@cetic.be
+        name: alexnuttinck
+      - email: sebastien.dupont@cetic.be
+        name: banzo


### PR DESCRIPTION
This PR adds the cetic helm charts repo to the Helm hub. (https://github.com/cetic/helm-charts)

For the moment, 2 charts are published:
* pgAdmin: https://github.com/cetic/helm-pgadmin
* apache nifi: https://github.com/cetic/helm-nifi

Maintainers:

* @alexnuttinck
* @banzo
