### PR TITLE
Add back missing lifen repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -141,3 +141,5 @@ sync:
       url: https://k8s.ory.sh/helm/charts
     - name: cetic
       url: https://cetic.github.io/helm-charts
+    - name: lifen
+      url: https://honestica.github.io/lifen-charts


### PR DESCRIPTION
I don't understand why it disappears, already added in https://github.com/helm/hub/commit/280979affd84501cd058da6a7caa8f3a0330cf90