### PR TITLE
Fix ory respository name.

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -137,7 +137,7 @@ sync:
       url: https://smallstep.github.io/helm-charts/
     - name: volcano
       url: https://volcano-sh.github.io/charts/
-    - name: smallstep
+    - name: ory
       url: https://k8s.ory.sh/helm/charts
     - name: cetic
       url: https://cetic.github.io/helm-charts


### PR DESCRIPTION
### Description
This PR fixes the repository name of ory.sh in the repo-values.yaml that has been incorrectly set to `smallstep` causing errors locating the smallstep and ory packages.