### PR TITLE
Adding simplyzee helm chart repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -149,3 +149,5 @@ sync:
       url: https://honestica.github.io/lifen-charts/
     - name: owkin
       url: https://owkin.github.io/charts
+    - name: simplyzee
+      url: https://charts.simplyzee.dev/

--- a/repos.yaml
+++ b/repos.yaml
@@ -392,3 +392,8 @@ repositories:
         name: Owkin DevOps
       - email: clement.gauter@owkin.com
         name: Clément Gautier
+  - name: simplyzee
+    url: https://charts.simplyzee.dev/
+    maintainers:
+      - email: zeieshanahmed@icloud.com
+        name: Zee Ahmed


### PR DESCRIPTION
This PR adds simplyzee charts helm repository.

Currently, I only have one helm chart which is [kube-rclone](https://github.com/zee-ahmed/kube-rclone)
More of my charts will be added in the upcoming weeks once I've refined them for public use. 

Maintainers:
[zee-ahmed](https://github.com/zee-ahmed/)