### PR TITLE
adding mirusresearch repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -149,3 +149,5 @@ sync:
       url: https://honestica.github.io/lifen-charts/
     - name: owkin
       url: https://owkin.github.io/charts
+    - name: mirusresearch
+      url: https://mirusresearch.github.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -392,3 +392,10 @@ repositories:
         name: Owkin DevOps
       - email: clement.gauter@owkin.com
         name: Clément Gautier
+  - name: mirusresearch
+    url: https://mirusresearch.github.io/charts/
+    maintainers:
+      - email: alec@mirusresearch.com
+        name: Alec Troemel
+      - email: don@mirusresearch.com
+        name: Don Spaulding


### PR DESCRIPTION
At the recommendation of someone [in this PR](https://github.com/helm/charts/pull/15187) 

Only chart right now is a wrapper around the new 2.0 haproxy ingress controller.

maintainers:
[alec troemel](https://github.com/AlecTroemel)