### PR TITLE
Add t3n Repository to Helm Hub

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -155,3 +155,5 @@ sync:
       url: https://mirusresearch.github.io/charts/
     - name: forseti-security
       url: https://forseti-security-charts.storage.googleapis.com/release/
+    - name: t3n
+      url: https://storage.googleapis.com/t3n-helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -411,3 +411,10 @@ repositories:
         name: Ken Evensen
       - email: shinhannah@forsetisecurity.org
         name: Hannah Shin
+  - name: t3n
+    url: https://storage.googleapis.com/t3n-helm-charts
+    maintainers:
+      - email: alec@mirusresearch.com
+        name: Alec Troemel
+      - email: don@mirusresearch.com
+        name: Don Spaulding

--- a/repos.yaml
+++ b/repos.yaml
@@ -414,7 +414,5 @@ repositories:
   - name: t3n
     url: https://storage.googleapis.com/t3n-helm-charts
     maintainers:
-      - email: alec@mirusresearch.com
-        name: Alec Troemel
-      - email: don@mirusresearch.com
-        name: Don Spaulding
+      - email: max.schmidt@t3n.de
+        name: mschmidt291


### PR DESCRIPTION
This commits adds the Helm Repository from https://github.com/t3n/helm-charts/ to Helm Hub