### PR TITLE
renaming Reactiveops to Fairwinds

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -64,8 +64,8 @@ sync:
       url: https://pnnl-miscscripts.github.io/charts
     - name: ceph-csi
       url: https://ceph.github.io/csi-charts
-    - name: reactiveops-stable
-      url: https://charts.reactiveops.com/stable
+    - name: fairwinds-stable
+      url: https://charts.fairwinds.com/stable
     - name: yourls
       url: https://charts.yourls.org
     - name: hazelcast

--- a/repos.yaml
+++ b/repos.yaml
@@ -174,11 +174,11 @@ repositories:
     maintainers:
       - email: ceph-devel@vger.kernel.org
         name: Ceph Developers
-  - name: reactiveops-stable
-    url: https://charts.reactiveops.com/stable
+  - name: fairwinds-stable
+    url: https://charts.fairwinds.com/stable
     maintainers:
-      - email: chart-maintainers@reactiveops.com
-        name: Chart Maintainers
+      - email: chart-maintainers@fairwinds.com
+        name: Fairwinds Chart Maintainers
   - name: yourls
     url: https://charts.yourls.org
     maintainers:


### PR DESCRIPTION
The company has been renamed to Fairwinds and our new helm repo is in place.