### PR TITLE
Add architectminds to Helm Hub

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -159,3 +159,5 @@ sync:
       url: https://helm.gethue.com
     - name: t3n
       url: https://storage.googleapis.com/t3n-helm-charts
+    - name: architectminds
+      url: https://architectminds.github.io/helm-charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -423,3 +423,10 @@ repositories:
     maintainers:
       - email: max.schmidt@t3n.de
         name: mschmidt291
+  - name: architectminds
+    url: https://architectminds.github.io/helm-charts/
+    maintainers:
+      - email: meena.kerolos+architectminds@gmail.com
+        name: Meena Alfons
+      - email: me@meenaalfons.com
+        name: Meena Alfons


### PR DESCRIPTION
Add architectminds Helm Repository to Helm Hub.

URL: https://architectminds.github.io/helm-charts/