### PR TITLE
Add Crowdfox Helm Repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -159,3 +159,5 @@ sync:
       url: https://helm.gethue.com
     - name: t3n
       url: https://storage.googleapis.com/t3n-helm-charts
+    - name: crowdfox
+      url: https://crowdfoxgmbh.github.io/cfcharts

--- a/repos.yaml
+++ b/repos.yaml
@@ -423,3 +423,10 @@ repositories:
     maintainers:
       - email: max.schmidt@t3n.de
         name: mschmidt291
+  - name: crowdfox
+    url: https://crowdfoxgmbh.github.io/cfcharts
+    maintainers:
+      - email: dev-ops@crowdfox.com
+        name: Crowdfox Team
+      - email: alwin@atk-solutions.de
+        name: Alwin Mark


### PR DESCRIPTION
This was the suggested way of @moarfr after I tried to add my chart to the helm/charts repository via https://github.com/helm/charts/pull/16031:

https://kubernetes.slack.com/archives/C6E3XH1ED/p1565256856098500