### PR TITLE
Add Kubedex Helm Repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -159,3 +159,5 @@ sync:
       url: https://helm.gethue.com
     - name: t3n
       url: https://storage.googleapis.com/t3n-helm-charts
+    - name: kubedex
+      url: https://kubedex.github.io/charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -423,3 +423,10 @@ repositories:
     maintainers:
       - email: max.schmidt@t3n.de
         name: mschmidt291
+  - name: kubedex
+    url: https://kubedex.github.io/charts
+    maintainers:
+      - email: sacreman@gmail.com
+        name: Steven Acreman
+      - email: gamunu.balagalla@outlook.com
+        name: Gamunu Balagalla


### PR DESCRIPTION
The main chart being the Kubedex helm-controller which is an Operator for installing Helm charts using CRD for config.
