### PR TITLE
Add repository for Apache Knox

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -170,3 +170,5 @@ sync:
       url: https://architectminds.github.io/helm-charts/
     - name: uswitch
       url: https://uswitch.github.io/kiam-helm-charts/charts/
+    - name: pfisterer-apache-knox-helm
+      url: https://pfisterer.github.io/apache-knox-helm/

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -170,5 +170,5 @@ sync:
       url: https://architectminds.github.io/helm-charts/
     - name: uswitch
       url: https://uswitch.github.io/kiam-helm-charts/charts/
-    - name: pfisterer-apache-knox-helm
+    - name: pfisterer-knox
       url: https://pfisterer.github.io/apache-knox-helm/

--- a/repos.yaml
+++ b/repos.yaml
@@ -454,3 +454,8 @@ repositories:
     maintainers:
       - email: cloud@uswitch.com
         name: uSwitch Infrastructure Team
+  - name:
+    url: https://pfisterer.github.io/apache-knox-helm/
+    maintainers:
+      - email: github@farberg.de
+        name: Dennis Pfisterer

--- a/repos.yaml
+++ b/repos.yaml
@@ -454,7 +454,7 @@ repositories:
     maintainers:
       - email: cloud@uswitch.com
         name: uSwitch Infrastructure Team
-  - name: pfisterer-apache-knox-helm
+  - name: pfisterer-knox
     url: https://pfisterer.github.io/apache-knox-helm/
     maintainers:
       - email: github@farberg.de

--- a/repos.yaml
+++ b/repos.yaml
@@ -454,7 +454,7 @@ repositories:
     maintainers:
       - email: cloud@uswitch.com
         name: uSwitch Infrastructure Team
-  - name:
+  - name: pfisterer-apache-knox-helm
     url: https://pfisterer.github.io/apache-knox-helm/
     maintainers:
       - email: github@farberg.de


### PR DESCRIPTION
This is a chart repository that contributes [Apache Knox](https://knox.apache.org/), which is an Application Gateway for interacting with the REST APIs and UIs of Apache Hadoop deployments. This chart is primarily intended to access HDFS from outside a Kubernetes cluster using simple REST APIs. 

Originally, this was intended to be integrated to stable/knox but the reviewers suggested to add it to helm hub using a github-hosted site. This is the original PR: <https://github.com/helm/charts/pull/16623>.