### PR TITLE
add repository for kubernetes external secrets

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -170,3 +170,5 @@ sync:
       url: https://architectminds.github.io/helm-charts/
     - name: uswitch
       url: https://uswitch.github.io/kiam-helm-charts/charts/
+    - name: kubernetes-external-secrets
+      url: https://godaddy.github.io/kubernetes-external-secrets/

--- a/repos.yaml
+++ b/repos.yaml
@@ -454,3 +454,10 @@ repositories:
     maintainers:
       - email: cloud@uswitch.com
         name: uSwitch Infrastructure Team
+  - name: kubernetes-external-secrets
+    url: https://godaddy.github.io/kubernetes-external-secrets/
+    maintainers:
+      - email: jxpearce@godaddy.com
+        name: jeffpearce
+      - email: klu6@godaddy.com
+        name: keweilu


### PR DESCRIPTION
This adds a chart which deploys [kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets) which allows you to use external secret management systems (e.g., AWS Secrets Manager) to securely add secrets in Kubernetes.

cc @silasbw @jeffpearce @JacopoDaeli