### PR TITLE
Added my repository where I am hosting prometheus-yace-exporter

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -176,3 +176,5 @@ sync:
       url: https://pfisterer.github.io/apache-knox-helm/
     - name: aerospike
       url: https://aerospike.github.io/aerospike-kubernetes-enterprise
+    - name: mogaal
+      url: https://mogaal.github.io/helm-charts/


### PR DESCRIPTION
Hello, 

I tried to upload to helm/charts/stable/ (helm/charts/pull/15760 ) but people are starting to encourage self-host charts

I hope is alright.

Alejandro