### PR TITLE
Commenting out kubernetes-external-secrets because errors

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -170,8 +170,8 @@ sync:
       url: https://architectminds.github.io/helm-charts/
     - name: uswitch
       url: https://uswitch.github.io/kiam-helm-charts/charts/
-    - name: kubernetes-external-secrets
-      url: https://godaddy.github.io/kubernetes-external-secrets/
+    # - name: kubernetes-external-secrets
+    #   url: https://godaddy.github.io/kubernetes-external-secrets/
     - name: pfisterer-knox
       url: https://pfisterer.github.io/apache-knox-helm/
     - name: aerospike

--- a/repos.yaml
+++ b/repos.yaml
@@ -454,13 +454,16 @@ repositories:
     maintainers:
       - email: cloud@uswitch.com
         name: uSwitch Infrastructure Team
-  - name: kubernetes-external-secrets
-    url: https://godaddy.github.io/kubernetes-external-secrets/
-    maintainers:
-      - email: jxpearce@godaddy.com
-        name: jeffpearce
-      - email: klu6@godaddy.com
-        name: keweilu
+  # The name kubernetes-external-secrets is too long in the current setup.
+  # The length is causing errors. Can we get a shorter name, linting, and a
+  # method to get a longer name? These are all open TODOs.
+  # - name: kubernetes-external-secrets
+  #   url: https://godaddy.github.io/kubernetes-external-secrets/
+  #   maintainers:
+  #     - email: jxpearce@godaddy.com
+  #       name: jeffpearce
+  #     - email: klu6@godaddy.com
+  #       name: keweilu
   - name: pfisterer-knox
     url: https://pfisterer.github.io/apache-knox-helm/
     maintainers:


### PR DESCRIPTION
The name kubernetes-external-secrets is too long in the current
setup and is causing k8s to throw errors.