### PR TITLE
Shortening HPE flexvolume name to fix error

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -190,7 +190,7 @@ sync:
       url: https://raw.githubusercontent.com/honeydipper/honeydipper-charts/master/
     - name: adwerx
       url: https://adwerx.github.io/charts/
-    - name: hpe-flexvolume-driver
+    - name: hpe-flexvolume
       url: https://hpe-storage.github.io/co-deployments/
     - name: squidex
       url: https://squidex.github.io/squidex-docker/

--- a/repos.yaml
+++ b/repos.yaml
@@ -506,7 +506,7 @@ repositories:
     maintainers:
       - email: jbielick@adwerx.com
         name: Josh Bielick
-  - name: hpe-flexvolume-driver
+  - name: hpe-flexvolume
     url: https://hpe-storage.github.io/co-deployments/
     maintainers:
       - email: hpe-containers-dev@hpe.com


### PR DESCRIPTION
The name was 3 characters too long. Shortening.

@shivamerla If you would like to have a different name please create a PR for the change.