### PR TITLE
Add Apache CouchDB helm repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -206,3 +206,5 @@ sync:
       url: https://oxyno-zeta.github.io/helm-charts/stable/
     - name: dragonchain
       url: https://dragonchain-charts.s3.amazonaws.com
+    - name: couchdb
+      url: https://apache.github.io/couchdb-helm/

--- a/repos.yaml
+++ b/repos.yaml
@@ -547,3 +547,10 @@ repositories:
         name: Dragonchain Team
       - email: adam@dragonchain.com
         name: Adam Crowder
+  - name: couchdb
+    url: https://apache.github.io/couchdb-helm/
+    maintainers:
+      - email: dev@couchdb.apache.org
+        name: Apache CouchDB Team
+      - email: willholley@apache.org
+        name: Will Holley


### PR DESCRIPTION
This will replace the CouchDB Helm chart in helm/charts/stable.