### PR TITLE
Add SubstraFoundation registry

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -208,3 +208,5 @@ sync:
       url: https://dragonchain-charts.s3.amazonaws.com
     - name: couchdb
       url: https://apache.github.io/couchdb-helm/
+    - name: substra
+      url: https://substrafoundation.github.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -554,3 +554,10 @@ repositories:
         name: Apache CouchDB Team
       - email: willholley@apache.org
         name: Will Holley
+  - name: substra
+    url: https://substrafoundation.github.io/charts/
+    maintainers:
+      - email: clement@gauter.im
+        name: Clément Gautier
+      - email: camille.marini@owkin.com
+        name: Camille Marini


### PR DESCRIPTION
Hello :wave:,

The [SubstraFoundation](https://www.substra.ai/) open sourced its decentralized AI framework recently and would like to publicly open the helm charts too. This registry will contains all the charts maintained by the Foundation.

PS: Thanks for the helm community for doing such a great tool :heart_eyes:  