### PR TITLE
Add Dask chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -208,3 +208,5 @@ sync:
       url: https://dragonchain-charts.s3.amazonaws.com
     - name: couchdb
       url: https://apache.github.io/couchdb-helm/
+    - name: dask
+      url: https://helm.dask.org/

--- a/repos.yaml
+++ b/repos.yaml
@@ -554,3 +554,14 @@ repositories:
         name: Apache CouchDB Team
       - email: willholley@apache.org
         name: Will Holley
+  - name: dask
+    url: https://helm.dask.org/
+    maintainers:
+      - email: df.rodriguez143@gmail.com
+        name: danielfrg
+      - email: mrocklin@gmail.com
+        name: mrocklin
+      - email: beberg@gmail.com
+        name: beberg
+      - email: jacob@tomlinson.email
+        name: jacobtomlinson


### PR DESCRIPTION
Add the helm chart repo for the [Dask community](https://dask.org).