### PR TITLE
Include 'tomkerkhove' Helm chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -214,3 +214,5 @@ sync:
       url: https://substrafoundation.github.io/charts/
     - name: cloudwatch-agent
       url: https://s2504s.github.io/charts/
+    - name: cryptlex
+      url: https://cryptlex.github.io/helm-charts/

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -216,3 +216,5 @@ sync:
       url: https://s2504s.github.io/charts/
     - name: cryptlex
       url: https://cryptlex.github.io/helm-charts/
+    - name: cloudbees
+      url: https://charts.cloudbees.com/public/cloudbees

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -218,3 +218,5 @@ sync:
       url: https://cryptlex.github.io/helm-charts/
     - name: cloudbees
       url: https://charts.cloudbees.com/public/cloudbees
+    - name: tomkerkhove
+      url: https://tomkerkhove.azurecr.io/helm/v1/repo

--- a/repos.yaml
+++ b/repos.yaml
@@ -577,3 +577,8 @@ repositories:
     maintainers:
       - email: s2504s@gmail.com
         name: Sergey Vasilyev
+  - name: cryptlex
+    url: https://cryptlex.github.io/helm-charts/
+    maintainers:
+      - email: support@cryptlex.com
+        name: Cryptlex Team

--- a/repos.yaml
+++ b/repos.yaml
@@ -587,3 +587,8 @@ repositories:
     maintainers:
       - email: charts@cloudbees.com
         name: CloudBees
+  - name: tomkerkhove
+    url: https://tomkerkhove.azurecr.io/helm/v1/repo
+    maintainers:
+      - email: kerkhove.tom@gmail.com
+        name: Tom Kerkhove

--- a/repos.yaml
+++ b/repos.yaml
@@ -582,3 +582,8 @@ repositories:
     maintainers:
       - email: support@cryptlex.com
         name: Cryptlex Team
+  - name: cloudbees
+    url: https://charts.cloudbees.com/public/cloudbees
+    maintainers:
+      - email: charts@cloudbees.com
+        name: CloudBees


### PR DESCRIPTION
Include `tomkerkhove` Helm chart repo which includes Helm charts for [Azure API Management Gateway](https://github.com/tomkerkhove/azure-api-management-gateway-helm)

Relates to https://github.com/tomkerkhove/azure-api-management-gateway-helm/issues/4.