### PR TITLE
Introduce 'tomkerkhove' chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -218,3 +218,5 @@ sync:
       url: https://s2504s.github.io/charts/
     - name: cloudbees
       url: https://charts.cloudbees.com/public/cloudbees
+    - name: tomkerkhove
+      url: https://tomkerkhove.azurecr.io/helm/v1/repo

--- a/repos.yaml
+++ b/repos.yaml
@@ -587,3 +587,8 @@ repositories:
     maintainers:
       - email: charts@cloudbees.com
         name: CloudBees
+  - name: tomkerkhove
+    url: https://tomkerkhove.azurecr.io/helm/v1/repo
+    maintainers:
+      - email: kerkhove.tom@gmail.com
+        name: Tom Kerkhove


### PR DESCRIPTION
Introduce 'tomkerkhove' chart repo that includes the Helm charts for all my OSS charts such as https://github.com/tomkerkhove/azure-api-management-gateway-helm.

Relates to tomkerkhove/azure-api-management-gateway-helm#4.