### PR TITLE
Use new Helm endpoint for KEDA

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -131,7 +131,7 @@ sync:
     - name: choerodon
       url: https://openchart.choerodon.com.cn/choerodon/c7n
     - name: kedacore
-      url: https://kedacore.azureedge.net/helm
+      url: https://kedacore.github.io/charts
     - name: seldon
       url: https://storage.googleapis.com/seldon-charts
     - name: gkarthiks

--- a/repos.yaml
+++ b/repos.yaml
@@ -330,7 +330,7 @@ repositories:
       - email: dong@wenqi.us
         name: Vink Dong
   - name: kedacore
-    url: https://kedacore.azureedge.net/helm
+    url: https://kedacore.github.io/charts
     maintainers:
       - email: ahmels@microsoft.com
         name: Ahmed ElSayed


### PR DESCRIPTION
Use new Helm endpoint for KEDA that is on https://kedacore.github.io/charts/

Relates to https://github.com/kedacore/charts/issues/3