### PR TITLE
Add Talend public Helm charts registry

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -226,3 +226,5 @@ sync:
       url: https://cgroschupp.github.io/helm-charts/
     - name: jenkins
       url: https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart
+    - name: talend
+      url: https://talend.github.io/helm-charts-public

--- a/repos.yaml
+++ b/repos.yaml
@@ -609,3 +609,10 @@ repositories:
         name: Tomasz Sęk
       - email: jal-khalili@virtuslab.com
         name: Jakub Al-Khalili
+  - name: talend
+    url: https://talend.github.io/helm-charts-public
+    maintainers:
+      - email: sgandon@talend.com
+        name: Sebastien Gandon
+      - email: asaintsever@talend.com
+        name: Alain Saint-Sever


### PR DESCRIPTION
Add Talend public Helm charts registry to Helm Hub

- Talend public Helm charts registry URL
- List of maintainers