### PR TITLE
Add AWS repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -230,3 +230,5 @@ sync:
       url: https://talend.github.io/helm-charts-public
     - name: softonic
       url: https://charts.softonic.io
+    - name: aws
+      url: https://aws.github.io/eks-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -621,3 +621,20 @@ repositories:
     maintainers:
       - email: sre@softonic.com
         name: Softonic
+  - name: aws
+    url: https://aws.github.io/eks-charts
+    maintainers:
+      - email: stefan.prodan@gmail.com
+        name: Stefan Prodan
+      - email: nic@amazon.com
+        name: Nick Turner
+      - email: jsstraub@amazon.com
+        name: James Straub
+      - email: meduri@amazon.com
+        name: Kiran Meduri
+      - email: sabhayav@amazon.com
+        name: Vipul Sabhayav
+      - email: jaypipes@amazon.com
+        name: Jay Pipes
+      - email: mhausler@amazon.com
+        name: Micah Hausler


### PR DESCRIPTION
This PR adds the AWS public Helm repository to Helm Hub.
Repo: https://github.com/aws/eks-charts