### PR TITLE
adds the Crossplane repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -232,3 +232,6 @@ sync:
       url: https://charts.softonic.io
     - name: aws
       url: https://aws.github.io/eks-charts
+    - name: crossplane
+      url: https://charts.crossplane.io/master/
+

--- a/repos.yaml
+++ b/repos.yaml
@@ -638,3 +638,8 @@ repositories:
         name: Jay Pipes
       - email: mhausler@amazon.com
         name: Micah Hausler
+  - name: crossplane
+    url: https://charts.crossplane.io/master/
+    maintainers:
+      - email: info@crossplane.io
+        name: Crossplane Maintainers


### PR DESCRIPTION
Adds the charts from <https://crossplane.io> to the hub (Crossplane is from the same team that started Rook).

Additional changes may be needed in https://github.com/crossplaneio/crossplane/tree/master/cluster/charts/crossplane to meet the 
https://github.com/helm/hub/blob/master/Repositories.md#repository-best-practices

https://github.com/crossplaneio/crossplane/pull/1102 adds the chart icon and has since been merged.  Let me know if there are any other requirements to merge.