### PR TITLE
Add WSO2 Helm chart repository and maintainers

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -232,3 +232,5 @@ sync:
       url: https://charts.softonic.io
     - name: aws
       url: https://aws.github.io/eks-charts
+    - name: wso2
+      url: https://helm.wso2.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -638,3 +638,18 @@ repositories:
         name: Jay Pipes
       - email: mhausler@amazon.com
         name: Micah Hausler
+  - name: wso2
+    url: https://helm.wso2.com
+    maintainers:
+      - email: chiranga@wso2.com
+        name: Chiranga Alwis
+      - email: aaquiff@wso2.com
+        name: Aaquiff Rauf
+      - email: thilinama@wso2.com>
+        name: Thilina Manamgoda
+      - email: dilana@wso2.com
+        name: Dilan U. Ariyaratne
+      - email: jayanga@wso2.com
+        name: Jayanga Dissanayake
+      - email: shariq@wso2.com
+        name: Shariq Muhammed 


### PR DESCRIPTION
This PR adds the WSO2 Helm chart [repository](https://helm.wso2.com).