### PR TITLE
Add inlets repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -53,6 +53,8 @@ sync:
       url: https://helm.elastic.co
     - name: openfaas
       url: https://openfaas.github.io/faas-netes
+    - name: inlets
+      url: https://inlets.github.io/inlets-operator/
     - name: odavid
       url: https://odavid.github.io/k8s-helm-charts
     - name: soluto

--- a/repos.yaml
+++ b/repos.yaml
@@ -138,6 +138,11 @@ repositories:
         name: Lucas Roesler
       - email: stefan.prodan@gmail.com
         name: Stefan Prodan
+  - name: inlets
+    url: https://inlets.github.io/inlets-operator
+    maintainers:
+      - email: alex@openfaas.com
+        name: Alex Ellis
   - name: odavid
     url: https://odavid.github.io/k8s-helm-charts
     maintainers:


### PR DESCRIPTION
This adds inlets and the inlets-operator from the same team as the 
OpenFaaS open source project. inlets is on the CNCF Landscape.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>