### PR TITLE
Add gp42 repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -242,3 +242,5 @@ sync:
       url: https://charts.cern.ch/cern/
     - name: chubaofs
       url: https://chubaofs.github.io/chubaofs-charts 
+    - name: ruguodangshi
+      url: https://ruguodangshi.github.io

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -245,4 +245,4 @@ sync:
     - name: ruguodangshi
       url: https://ruguodangshi.github.io
     - name: gp42
-      url: https://github.com/gp42/helm-charts
+      url: https://ops42.org/helm-charts

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -244,3 +244,5 @@ sync:
       url: https://chubaofs.github.io/chubaofs-charts 
     - name: ruguodangshi
       url: https://ruguodangshi.github.io
+    - name: gp42
+      url: https://github.com/gp42/helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -678,3 +678,8 @@ repositories:
     maintainers:
       - email: shih5@chinaunicom.cn
         name: Hao Shi
+  - name: gp42
+    url: https://ops42.org
+    maintainers:
+      - email: gennadiy.potapov@gmail.com
+        name: Gennady Potapov

--- a/repos.yaml
+++ b/repos.yaml
@@ -682,4 +682,4 @@ repositories:
     url: https://ops42.org
     maintainers:
       - email: gennadiy.potapov@gmail.com
-        name: Gennady Potapov
+        name: Gennady Potapov 

--- a/repos.yaml
+++ b/repos.yaml
@@ -684,7 +684,7 @@ repositories:
       - email: shih5@chinaunicom.cn
         name: Hao Shi
   - name: gp42
-    url: https://ops42.org
+    url: https://ops42.org/helm-charts
     maintainers:
       - email: gennadiy.potapov@gmail.com
         name: Gennady Potapov

--- a/repos.yaml
+++ b/repos.yaml
@@ -673,3 +673,8 @@ repositories:
     maintainers:
       - email: chengyu_l@126.com
         name: Chengyu Liu
+  - name: ruguodangshi
+    url: https://ruguodangshi.github.io
+    maintainers:
+      - email: shih5@chinaunicom.cn
+        name: Hao Shi

--- a/repos.yaml
+++ b/repos.yaml
@@ -682,4 +682,4 @@ repositories:
     url: https://ops42.org
     maintainers:
       - email: gennadiy.potapov@gmail.com
-        name: Gennady Potapov 
+        name: Gennady Potapov


### PR DESCRIPTION
Following the conversation in: https://github.com/helm/charts/pull/17398, I would like to publish the `calico-aws` chart on https://hub.helm.sh.

This is a new Helm chart for running Project Calico on AWS EKS.

Signed-off-by: Gennady Potapov <gennadiy.potapov@gmail.com>