### PR TITLE
update Talend url to expose only stable registry

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -619,7 +619,7 @@ repositories:
       - email: jal-khalili@virtuslab.com
         name: Jakub Al-Khalili
   - name: talend
-    url: https://talend.github.io/helm-charts-public
+    url: https://talend.github.io/helm-charts-public/stable
     maintainers:
       - email: sgandon@talend.com
         name: Sebastien Gandon


### PR DESCRIPTION
Talend has now a stable and incubator registry, this PR is there to expose in the hub only the stable registry.
Thanks.