### PR TITLE
All Citrix Helm charts in single HELM Chart repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -81,10 +81,8 @@ sync:
       url: https://helm.nginx.com/stable
     - name: nginx-edge
       url: https://helm.nginx.com/edge
-    - name: cic
-      url: https://citrix.github.io/citrix-k8s-ingress-controller/
     - name: citrix
-      url: https://citrix.github.io/citrix-istio-adaptor/
+      url: https://citrix.github.io/citrix-helm-charts/
     - name: zooz
       url: https://zooz.github.io/helm/
     - name: rancher-stable

--- a/repos.yaml
+++ b/repos.yaml
@@ -216,16 +216,12 @@ repositories:
     url: https://helm.nginx.com/edge
     maintainers:
       - email: kubernetes@nginx.com
-  - name: cic
-    url: https://citrix.github.io/citrix-k8s-ingress-controller/
-    maintainers:
-      - email: priyanka.sharma@citrix.com
-      - email: subash.dangol@citrix.com
   - name: citrix
-    url: https://citrix.github.io/citrix-istio-adaptor/
+    url: https://citrix.github.io/citrix-helm-charts/
     maintainers:
       - email: dhiraj.gedam@citrix.com
       - email: subash.dangol@citrix.com
+      - email: priyanka.sharma@citrix.com
   - name: zooz
     url: https://zooz.github.io/helm/
     maintainers:


### PR DESCRIPTION
We kept all helm charts developed and maintained by Citrix in one repository and want this to be available on Helm Hub.