### PR TITLE
Fix Talend Helm chart stable repo url

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -227,7 +227,7 @@ sync:
     - name: jenkins
       url: https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart
     - name: talend
-      url: https://talend.github.io/helm-charts-public
+      url: https://talend.github.io/helm-charts-public/stable
     - name: softonic
       url: https://charts.softonic.io
     - name: aws


### PR DESCRIPTION
Signed-off-by: Alain Saint-Sever <asaintsever@talend.com>

Fix Talend Helm chart repo url.