### PR TITLE
Add Wavefront repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -268,3 +268,5 @@ sync:
       url: https://jaegertracing.github.io/helm-charts
     - name: riskfocus
       url: https://riskfocus.github.io/helm-charts-public/
+    - name: wavefront
+      url: https://wavefronthq.github.io/helm/

--- a/repos.yaml
+++ b/repos.yaml
@@ -753,3 +753,10 @@ repositories:
     maintainers:
       - email: charts-maintainers@riskfocus.com
         name: Riskfocus
+  - name: wavefront
+    url: https://wavefronthq.github.io/helm/
+    maintainers:
+      - email: ptessier@vmware.com
+        name: Pierre Tessier
+      - email: rvikram@vmare.com
+        name: Vikram Raman


### PR DESCRIPTION
Wavefront repo to host charts per deprecation of helm/charts.