### PR TITLE
Add cloudposse charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -23,6 +23,8 @@ sync:
       url: https://charts.rimusz.net
     - name: buildkite
       url: https://buildkite.github.io/charts
+    - name: cloudposse
+      url: https://charts.cloudposse.com/incubator/
     - name: keel
       url: https://charts.keel.sh
     - name: appscode

--- a/repos.yaml
+++ b/repos.yaml
@@ -55,6 +55,11 @@ repositories:
     maintainers:
       - email: rmocius@gmail.com
         name: rimusz
+  - name: cloudposse
+    url: https://charts.cloudposse.com/incubator/
+    maintainers:
+      - email: ops@cloudposse.com
+      - name: cloudposse
   - name: keel
     url: https://charts.keel.sh
     maintainers:


### PR DESCRIPTION
Add the [cloudposse incubator helm chart repository](https://github.com/cloudposse/charts) `https://charts.cloudposse.com/incubator/` 

Note to maintainers: have you consider sorting the configs based on repo names?