### PR TITLE
Add the Meshery Helm chart to Helm.Hub

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -304,3 +304,5 @@ sync:
       url: https://oteemo.github.io/charts/
     - name: tietoevryfs
       url: https://evryfs.github.io/helm-charts/
+    - name: meshery
+      url: https://meshery.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -865,3 +865,8 @@ repositories:
    maintainers:
      - name: TietoEVRY Financial Services
        email: fsdevops@evry.com
+ - name: meshery
+   url: https://meshery.io/charts/
+   maintainers:
+     - name: Aisuko
+       email: urakiny@gmail.com


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

**Introducing Meshery**
A multi-service mesh management plane adopting, operating and developing on different service meshes. Meshery faciliates learning about functionality and performance of service meshes and incorporates collection and display of metrics from applications running on or across service meshes.

**The project address**

https://github.com/layer5io/meshery

It's our [layer5io community](https://github.com/layer5io) pleasure that can add the Meshery Helm chart into the Helm.hub.

