### PR TITLE
Fix Bitnami URL

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -32,7 +32,7 @@ sync:
     - name: gitlab
       url: https://charts.gitlab.io/
     - name: bitnami
-      url: https://charts.bitnami.com
+      url: https://charts.bitnami.com/bitnami
     - name: fluxcd
       url: https://charts.fluxcd.io
     - name: jetstack

--- a/repos.yaml
+++ b/repos.yaml
@@ -76,7 +76,7 @@ repositories:
       - name: GitLab
         email: distribution@gitlab.com
   - name: bitnami
-    url: https://charts.bitnami.com
+    url: https://charts.bitnami.com/bitnami
     maintainers:
       - name: Bitnami
         email: containers@bitnami.com


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <crhernandez@bitnami.com>

Although both URLs work fine because they are a mirror, we are working on unifying the format everywhere (READMEs, kubeapps, Helm hub, etc).