### PR TITLE
Add Quarks charts repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -304,3 +304,5 @@ sync:
       url: https://oteemo.github.io/charts/
     - name: tietoevryfs
       url: https://evryfs.github.io/helm-charts/
+    - name: quarks
+      url: https://cloudfoundry-incubator.github.io/quarks-helm/

--- a/repos.yaml
+++ b/repos.yaml
@@ -865,3 +865,8 @@ repositories:
    maintainers:
      - name: TietoEVRY Financial Services
        email: fsdevops@evry.com
+ - name: quarks
+   url: https://cloudfoundry-incubator.github.io/quarks-helm/
+   maintainers:
+     - name: project-quarks
+       email: project-quarks@googlegroups.com


### PR DESCRIPTION
The [Quarks project](https://www.cloudfoundry.org/project-quarks/) is part of the CloudFoundry Foundation. The repository contains the [cf-operator](https://github.com/cloudfoundry-incubator/cf-operator), which we use to convert BOSH releases into Kubernetes workloads. [kubecf](https://kubecf.suse.dev/) uses this to deploy CloudFoundry on Kubernetes.