### PR TITLE
Add Eclipse Dirigible charts repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -322,3 +322,5 @@ sync:
       url: https://meshery.io/charts/
     - name: influxdata
       url: https://helm.influxdata.com/
+    - name: eclipse-dirigible
+      url: https://dirigiblelabs.github.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -916,3 +916,12 @@ repositories:
         email: rawkode@influxdata.com
       - name: Giacomo Tirabassi
         email: giacomo@influxdata.com
+  - name: eclipse-dirigible
+    url: https://dirigiblelabs.github.io/charts/
+    maintainers:
+      - email: yordan.pavlov@sap.com
+        name: Yordan Pavlov
+      - email: nedelcho.delchev@sap.com
+        name: Nedelcho Delchev
+      - email: georgi.pavlov@sap.com
+        name: Georgi Pavlov


### PR DESCRIPTION
[Eclipse Dirigible](https://www.dirigible.io/) project is part of the Eclipse Foundation. Dirigible is a cloud development platform providing development tools (Web IDE) and runtime environment (Java based) for In-System Development and Low-Code/No-Code Development. The repository contains basic setup of Dirigible for Kubernetes. More advance setups to be added, for example:
- [Kubernetes, Keycloak, PostgreSQL & Dirigible](https://www.dirigible.io/blogs/2018/06/25/kubernetes_keycloak_postgresql_dirigible.html)