### PR TITLE
Point to new Camptocamp repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -331,7 +331,7 @@ sync:
     - name: enapter
       url: https://enapter.github.io/charts/
     - name: camptocamp
-      url: http://camptocamp.github.io/charts/
+      url: http://charts.camptocamp.com
     - name: camel-k
       url: https://apache.github.io/camel-k/charts/
     - name: trickster

--- a/repos.yaml
+++ b/repos.yaml
@@ -943,7 +943,7 @@ repositories:
       - name: Enapter
         email: admin@enapter.com
   - name: camptocamp
-    url: http://camptocamp.github.io/charts/
+    url: http://charts.camptocamp.com
     maintainers:
       - name: Camptocamp Infrastructure Department
         email: kubernetes@camptocamp.com


### PR DESCRIPTION
I hadn't realized Camptocamp had a new Chartmuseum repository, so here's the fixed URL.