### PR TITLE
Add prometheus-msteams chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -342,3 +342,5 @@ sync:
       url: https://helm.runix.net/
     - name: jitterbit
       url: https://jitterbit.github.io/charts/
+    - name: prometheus-msteams
+      url: https://prometheus-msteams.github.io/helm-chart

--- a/repos.yaml
+++ b/repos.yaml
@@ -976,3 +976,10 @@ repositories:
     maintainers:
       - name: Sean Krail
         email: sean.krail@jitterbit.com
+  - name: prometheus-msteams
+    url: https://prometheus-msteams.github.io/helm-chart
+    maintainers:
+      - name: John Bryan Sazon
+        email: jb.jorge.sazon@gmail.com
+      - name: Andy Knapp
+        email: andy.knapp.ak@googlemail.com


### PR DESCRIPTION
This change adds the https://github.com/prometheus-msteams/prometheus-msteams project helm chart to helm hub.