### PR TITLE
Add repo: brannon

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -346,3 +346,5 @@ sync:
       url: https://franz.com/ftp/pub/helm/charts/
     - name: prometheus-msteams
       url: https://prometheus-msteams.github.io/helm-chart
+    - name: brannon
+      url: https://helm.brannon.online

--- a/repos.yaml
+++ b/repos.yaml
@@ -988,3 +988,8 @@ repositories:
         email: jb.jorge.sazon@gmail.com
       - name: Andy Knapp
         email: andy.knapp.ak@googlemail.com
+  - name: brannon
+    url: https://helm.brannon.online
+    maintainers:
+      - name: Brannon Dorsey
+        email: brannon@brannondorsey.com


### PR DESCRIPTION
I host a [repo](https://github.com/brannondorsey/helm-charts/) dedicated to charts for distributed computing projects like Folding@home and Prime95/GIMPS.

Right now there are three charts, but I'm hoping to add more in the future as well as maintain the existing ones.

I'd love to add this chart to the Hub. Let me know if I can answer any questions or provide any additional information to make that happen. 