### PR TITLE
Add equinor-charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -367,4 +367,4 @@ sync:
     - name: kuberhealthy
       url: https://comcast.github.io/kuberhealthy/helm-repos
     - name: equinor-charts
-      url: https://equinor.github.io/equinor-charts/charts/
+      url: https://equinor.github.io/helm-charts/charts/

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -366,5 +366,5 @@ sync:
       url: https://dacruz21.github.io/helm-charts
     - name: kuberhealthy
       url: https://comcast.github.io/kuberhealthy/helm-repos
-    - name: neo4j-community
-      url: https://equinor.github.io/neo4j-charts/charts/
+    - name: equinor-charts
+      url: https://equinor.github.io/equinor-charts/charts/

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -366,3 +366,5 @@ sync:
       url: https://dacruz21.github.io/helm-charts
     - name: kuberhealthy
       url: https://comcast.github.io/kuberhealthy/helm-repos
+    - name: neo4j-community
+      url: https://equinor.github.io/neo4j-charts/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1042,3 +1042,8 @@ repositories:
     maintainers:
       - name: tp-cts-kubesquad
       - email: tp-cts-kubesquad@comcast.com
+  - name: neo4j-community
+    url: https://equinor.github.io/neo4j-charts/charts/
+    maintainers:
+      - name: Stian Ovrevage
+      - email: stian@peritusconsulting.no

--- a/repos.yaml
+++ b/repos.yaml
@@ -1043,7 +1043,7 @@ repositories:
       - name: tp-cts-kubesquad
       - email: tp-cts-kubesquad@comcast.com
   - name: equinor-charts
-    url: https://equinor.github.io/equinor-charts/charts/
+    url: https://equinor.github.io/helm-charts/charts/
     maintainers:
       - name: Stian Ovrevage
       - email: stian@peritusconsulting.no

--- a/repos.yaml
+++ b/repos.yaml
@@ -1042,8 +1042,8 @@ repositories:
     maintainers:
       - name: tp-cts-kubesquad
       - email: tp-cts-kubesquad@comcast.com
-  - name: neo4j-community
-    url: https://equinor.github.io/neo4j-charts/charts/
+  - name: equinor-charts
+    url: https://equinor.github.io/equinor-charts/charts/
     maintainers:
       - name: Stian Ovrevage
       - email: stian@peritusconsulting.no


### PR DESCRIPTION
Based on neo4j (-enterprise) chart from https://github.com/helm/charts/tree/master/stable/neo4j

Passes `ct lint`:

```
$ ct lint --chart-dirs charts/ --all --debug --remote origin --target-branch master
Linting charts...
Version increment checking disabled.
------------------------------------------------------------------------------------------------------------------------
 Configuration
------------------------------------------------------------------------------------------------------------------------
Remote: origin
TargetBranch: master
BuildId:
LintConf: /etc/ct/lintconf.yaml
ChartYamlSchema: /etc/ct/chart_schema.yaml
ValidateMaintainers: true
ValidateChartSchema: true
ValidateYaml: true
CheckVersionIncrement: false
ProcessAllCharts: true
Charts: []
ChartRepos: []
ChartDirs: [charts/]
ExcludedCharts: []
HelmExtraArgs:
HelmRepoExtraArgs: []
Debug: true
Upgrade: false
SkipMissingValues: false
Namespace:
ReleaseLabel:
------------------------------------------------------------------------------------------------------------------------
>>> helm version --short

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 neo4j-community => (version: "1.0.0", path: "charts/neo4j-community")
------------------------------------------------------------------------------------------------------------------------

>>> helm dependency build charts/neo4j-community
Linting chart 'neo4j-community => (version: "1.0.0", path: "charts/neo4j-community")'
>>> yamale --schema /etc/ct/chart_schema.yaml charts/neo4j-community/Chart.yaml
Validating /mnt/d/Data/go/src/github.com/equinor/neo4j-charts/charts/neo4j-community/Chart.yaml...
Validation success! 👍
>>> yamllint --config-file /etc/ct/lintconf.yaml charts/neo4j-community/Chart.yaml
>>> yamllint --config-file /etc/ct/lintconf.yaml charts/neo4j-community/values.yaml
Validating maintainers...
>>> git ls-remote --get-url origin
>>> helm lint charts/neo4j-community
==> Linting charts/neo4j-community

1 chart(s) linted, 0 chart(s) failed
All charts linted successfully
------------------------------------------------------------------------------------------------------------------------
 ✔︎ neo4j-community => (version: "1.0.0", path: "charts/neo4j-community")
------------------------------------------------------------------------------------------------------------------------
```