### PR TITLE
Add Helm charts for NATS.io

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -374,3 +374,5 @@ sync:
       url: https://carlosjgp.github.io/open-charts/
     - name: fyipe
       url: https://fyipe.com/chart
+    - name: nats
+      url: https://nats-io.github.io/k8s/helm/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1062,3 +1062,8 @@ repositories:
     maintainers:
       - name: Fyipe Engineering Team
         email: engineering@fyipe.com
+  - name: nats
+    url: https://nats-io.github.io/k8s/helm/charts/
+    maintainers:
+      - name: Waldemar Quevedo
+      - email: wally@nats.io


### PR DESCRIPTION
We have started to officially support Helm charts for NATS.io and we'd like to add them to the Helm Hub repo :)

```
> helm repo add nats https://nats-io.github.io/k8s/helm/charts/
> helm repo update

> helm repo list
NAME          	URL 
nats          	https://nats-io.github.io/k8s/helm/charts/

> helm install my-nats nats/nats
> helm install my-stan nats/stan --set stan.nats.url=nats://my-nats:4222
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>