### PR TITLE
Add carlosjgp charts repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -370,3 +370,5 @@ sync:
       url: https://helm-charts.touk.pl/public/
     - name: codimd
       url: https://helm.codimd.dev/
+    - name: carlosjgp
+      url: https://carlosjgp.github.io/open-charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1052,3 +1052,8 @@ repositories:
     maintainers:
       - name: HackMD Inc. Dev Team
         email: support@hackmd.io
+  - name: carlosjgp
+    url: https://carlosjgp.github.io/open-charts/
+    maintainers:
+      - name: Carlos Juan Gómez Peñalver
+        email: carlosjuangp@gmail.com


### PR DESCRIPTION
Add https://github.com/carlosjgp/open-charts to Helm Hub

This repo is using [helm/chart-testing-action](https://github.com/helm/chart-testing-action)
and [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) GitHub actions
to automate the code flow