### PR TITLE
Add Verdaccio Chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -386,3 +386,5 @@ sync:
       url: https://nexus.tremolo.io/repository/helm/
     - name: cronce
       url: https://charts.cronce.io/
+    - name: verdaccio
+      url: https://charts.verdaccio.org/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1094,3 +1094,10 @@ repositories:
     maintainers:
       - name: Mike Cronce
         email: helm@cronce.io
+  - name: verdaccio
+    url: https://charts.verdaccio.org/
+    maintainers:
+      - name: Juan Picado
+        email: juanpicado19@gmail.com
+      - name: Jhon Mike
+        email: jhon.msdev@gmail.com


### PR DESCRIPTION
We are moving Helm Verdaccio repository  from `stable/verdaccio` to our own organization.

Signed-off-by: Juan Picado @jotadeveloper <juanpicado19@gmail.com>