### PR TITLE
Add Redash repo.

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -392,3 +392,5 @@ sync:
       url: https://charts.enix.io/
     - name: mox
       url: https://helm.mox.sh/
+    - name: redash
+      url: https://getredash.github.io/contrib-helm-chart/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1111,3 +1111,8 @@ repositories:
     maintainers:
       - name: Javier Moreno
         email: jmox@protonmail.com
+  - name: redash
+    url: https://getredash.github.io/contrib-helm-chart/
+    maintainers:
+      - name: Owen Barton
+        email: owen.barton@civicactions.com


### PR DESCRIPTION
This chart started life in a [charts/stable repo PR](https://github.com/helm/charts/pull/5071) but was adopted by the Redash organization and has since had several improvements and a recent 2.0.0 release. Corresponding upstream issue https://github.com/getredash/contrib-helm-chart/issues/4