### PR TITLE
Add datawire as a helm chart repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -440,3 +440,5 @@ sync:
       url: https://bloomberg.github.io/solr-operator/charts
     - name: inaccel
       url: https://setup.inaccel.com/helm
+    - name: datawire
+      url: https://getambassador.io/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1249,3 +1249,8 @@ repositories:
     maintainers:
       - name: InAccel
         email: info@inaccel.com
+  - name: datawire
+    url: https://getambassador.io/
+    maintainers:
+      - name: Datwire
+        email: dev@datawire.io


### PR DESCRIPTION
This PR is to add the `datawire` chart repository which hosts the Ambassador chart built from https://github.com/datawire/ambassador-chart. This should replace `stable/ambassador` which was deprecated in January.