### PR TITLE
Add eddycharly repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -440,3 +440,5 @@ sync:
       url: https://bloomberg.github.io/solr-operator/charts
     - name: inaccel
       url: https://setup.inaccel.com/helm
+    - name: eddycharly
+      url: https://eddycharly.github.io/tekton-helm

--- a/repos.yaml
+++ b/repos.yaml
@@ -1249,3 +1249,8 @@ repositories:
     maintainers:
       - name: InAccel
         email: info@inaccel.com
+  - name: eddycharly
+    url: https://eddycharly.github.io/tekton-helm
+    maintainers:
+      - name: eddycharly
+        email: ceb@agriconomie.com


### PR DESCRIPTION
This PR adds the `eddycharly` chart repository which hosts charts for Tekton components (pipelines, triggers and dashboard).

