### PR TITLE
Add neo4j helm chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -440,3 +440,5 @@ sync:
       url: https://bloomberg.github.io/solr-operator/charts
     - name: inaccel
       url: https://setup.inaccel.com/helm
+    - name: neo4j
+      url: https://neo4j-contrib.github.io/neo4j-helm/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1249,3 +1249,8 @@ repositories:
     maintainers:
       - name: InAccel
         email: info@inaccel.com
+  - name: neo4j
+    url: https://neo4j-contrib.github.io/neo4j-helm/
+    maintainers:
+      - name: Neo4j
+        email: ecosystem@neo4j.com


### PR DESCRIPTION
We are in the process of deprecating the chart here: https://github.com/helm/charts/tree/master/stable/neo4j and migrating to the new self-hosted chart which is the subject of this PR.   (I'll open a separate PR to deprecate that one and provide pointers to the new one)

The new chart is ~ 90% the same as the one that's being deprecated, with more updates, fixes & features.   It passes helm lint and testing in the CI chain, and should follow all of the existing best practices already required by the other repo.