### PR TITLE
Add geek-cookbook charts

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -109,7 +109,7 @@ sync:
       url: https://funkypenguin.github.io/helm-charts
     - name: geek-cookbook
       url: https://geek-cookbook.github.io/charts
-      - name: mattermost
+    - name: mattermost
       url: https://helm.mattermost.com
     - name: emberstack
       url: https://emberstack.github.io/helm-charts

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -107,7 +107,9 @@ sync:
       url: https://herbrandson.github.io/k8dash/helm
     - name: funkypenguin
       url: https://funkypenguin.github.io/helm-charts
-    - name: mattermost
+    - name: geek-cookbook
+      url: https://geek-cookbook.github.io/charts
+      - name: mattermost
       url: https://helm.mattermost.com
     - name: emberstack
       url: https://emberstack.github.io/helm-charts


### PR DESCRIPTION
Hey guys,

I'm migrating charts from the funkypenguin repo to the geek-cookbook (a GitHub org) repo.

All charts are linted and tested with chart-tester, which forces versions to be immutable. Charts are each sourced from their own repositories, and consolidated to the charts repository to keep it tidy.