### PR TITLE
Add geek-cookbook

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -107,6 +107,8 @@ sync:
       url: https://herbrandson.github.io/k8dash/helm
     - name: funkypenguin
       url: https://funkypenguin.github.io/helm-charts
+    - name: geek-cookbook
+      url: https://geek-cookbook.github.io/charts
     - name: mattermost
       url: https://helm.mattermost.com
     - name: emberstack

--- a/repos.yaml
+++ b/repos.yaml
@@ -287,6 +287,10 @@ repositories:
     url: https://funkypenguin.github.io/helm-charts
     maintainers:
       - email: helm-charts@funkypenguin.co.nz
+  - name: geek-cookbook
+    url: https://geek-cookbook.github.io/charts
+    maintainers:
+      - email: helm-charts@funkypenguin.co.nz
   - name: mattermost
     url: https://helm.mattermost.com
     maintainers:


### PR DESCRIPTION
A redo of #347, much cleaner, with signoff ;)

---
Hey guys,

I'm migrating charts from the funkypenguin repo to the geek-cookbook (a GitHub org) repo.

All charts are linted and tested with chart-tester, which forces versions to be immutable. Charts are each sourced from their own repositories, and consolidated to the charts repository to keep it tidy.