### PR TITLE
Add Hazelcast Jet charts

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -83,6 +83,8 @@ sync:
       url: https://charts.yourls.org
     - name: hazelcast
       url: https://hazelcast.github.io/charts/
+    - name: hazelcast-jet
+      url: https://hazelcast.github.io/charts/
     - name: nginx
       url: https://helm.nginx.com/stable
     - name: nginx-edge

--- a/repos.yaml
+++ b/repos.yaml
@@ -230,8 +230,17 @@ repositories:
     maintainers:
       - email: rafal@hazelcast.com
         name: Rafal Leszko
-      - email: guglielmo@hazelcast.com
-        name: Guglielmo Nigri
+      - email: hasan@hazelcast.com
+        name: Hasan Celik
+      - email: mesut@hazelcast.com
+        name: Mesut Celik
+  - name: hazelcast-jet
+    url: https://hazelcast.github.io/charts/
+    maintainers:
+      - email: rafal@hazelcast.com
+        name: Rafal Leszko
+      - email: hasan@hazelcast.com
+        name: Hasan Celik
       - email: mesut@hazelcast.com
         name: Mesut Celik
   - name: nginx


### PR DESCRIPTION
`hazelcast/hazelcast-jet` and `hazelcast/hazeclast-jet-enterprise` charts are [not listed at HelmHub](https://hub.helm.sh/charts?q=hazelcast).

Those Jet charts are hosted at the same URL(https://hazelcast.github.io/charts/) with hazelcast ones so should I update [repo-values.yaml](https://github.com/helm/hub/blob/master/config/repo-values.yaml) file as well?
```
...
    - name: hazelcast
      url: https://hazelcast.github.io/charts/
    - name: hazelcast-jet
      url: https://hazelcast.github.io/charts/
...
```

Signed-off-by: hasancelik <hasan@hazelcast.com>