### PR TITLE
Add sysdiglabs repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -458,3 +458,5 @@ sync:
       url: https://opennode.github.io/waldur-helm/
     - name: milvus
       url: https://milvus-io.github.io/milvus-helm/
+    - name: sysdiglabs
+      url: https://sysdiglabs.github.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1294,3 +1294,10 @@ repositories:
         email: dev.milvus@zilliz.com
       - name: community
         email: community@zilliz.com
+  - name: sysdiglabs
+    url: https://sysdiglabs.github.io/charts/
+    maintainers:
+      - name: team cloud native
+        email: team-cloud-native@sysdig.com
+      - name: Néstor Salceda
+        email: nestor.salceda@sysdig.com


### PR DESCRIPTION
This PR adds sysdiglabs repo to hub.helm.sh

Signed-off-by: Néstor Salceda <nestor.salceda@sysdig.com>