### PR TITLE
Shortening the Kubernetes name to k8s

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -462,5 +462,5 @@ sync:
       url: https://sysdiglabs.github.io/charts/
     - name: yunikorn
       url: https://apache.github.io/incubator-yunikorn-release
-    - name: kubernetes-dashboard
+    - name: k8s-dashboard
       url: https://kubernetes.github.io/dashboard

--- a/repos.yaml
+++ b/repos.yaml
@@ -1306,7 +1306,7 @@ repositories:
     maintainers:
       - name: YuniKorn Dev
         email: dev@yunikorn.apache.org
-  - name: kubernetes-dashboard
+  - name: k8s-dashboard
     url: https://kubernetes.github.io/dashboard
     maintainers:
       - name: Kubernetes SIG UI


### PR DESCRIPTION
The name is used as part of the names of k8s assets. This can cause
length issues and the Kubernetes name was too long. Shortening.