### PR TITLE
Add the CockroachDB helm charts repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -25,6 +25,8 @@ sync:
       url: https://buildkite.github.io/charts
     - name: cloudposse
       url: https://charts.cloudposse.com/incubator/
+    - name: cockroachdb
+      url: https://charts.cockroachdb.com/
     - name: keel
       url: https://charts.keel.sh
     - name: webhookrelay

--- a/repos.yaml
+++ b/repos.yaml
@@ -60,6 +60,11 @@ repositories:
     maintainers:
       - email: ops@cloudposse.com
       - name: cloudposse
+  - name: cockroachdb
+    url: https://charts.cockroachdb.com/
+    maintainers:
+      - email: helm-charts@cockroachlabs.com
+        name: Cockroach Labs
   - name: keel
     url: https://charts.keel.sh
     maintainers:


### PR DESCRIPTION
This is the official helm chart repository for CockroachDB.