### PR TITLE
Add traefik v2 helm chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -482,3 +482,5 @@ sync:
       url: https://helm.kafkaesque.io
     - name: cape
       url: https://charts.cape.sh
+    - name: traefik
+      url: https://containous.github.io/traefik-helm-chart

--- a/repos.yaml
+++ b/repos.yaml
@@ -1368,3 +1368,8 @@ repositories:
     maintainers:
       - name: Cloud Native Team
         email: cloudnative@biqmind.com
+  - name: traefik
+    url: https://containous.github.io/traefik-helm-chart
+    maintainers:
+      - name: Containous Team
+        email: helm-charts@containo.us


### PR DESCRIPTION
### Description

This PR adds the Traefik v2 helm chart to hub.helm.sh

Traefik helm chart repo: https://github.com/containous/traefik-helm-chart

Fixes: https://github.com/containous/traefik-helm-chart/issues/211