### PR TITLE
Add the official Apache Pulsar helm chart repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -481,6 +481,8 @@ sync:
     - name: openebs
       url: https://openebs.github.io/charts
     - name: pulsar
+      url: https://pulsar.apache.org/charts
+    - name: kafkaesque
       url: https://helm.kafkaesque.io
     - name: cape
       url: https://charts.cape.sh

--- a/repos.yaml
+++ b/repos.yaml
@@ -1362,6 +1362,11 @@ repositories:
       - name: Prateek Pandey
         email: prateek.pandey@openebs.io
   - name: pulsar
+    url: https://pulsar.apache.org/charts
+    maintainers:
+      - name: Apache Pulsar Team
+        email: dev@pulsar.apache.org
+  - name: kafkaesque
     url: https://helm.kafkaesque.io
     maintainers:
       - name: Chris Bartholomew


### PR DESCRIPTION
The helm chart added in helm/hub#374 is not maintained by the Pulsar project. Pulsar team officially maintains a Helm chart for its releases. This pull request is adding the official Pulsar helm chart. I have moved the previous chart to kafkaesque.