### PR TITLE
add falcosecurity repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -512,3 +512,5 @@ sync:
       url: https://twingate.github.io/helm-charts
     - name: longhorn
       url: https://charts.longhorn.io
+    - name: falcosecurity
+      url: https://falcosecurity.github.io/charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -1453,3 +1453,9 @@ repositories:
         email: maintainers@longhorn.io
       - name: Sheng Yang
         email: sheng@yasker.org
+  - name: falcosecurity
+    url: https://falcosecurity.github.io/charts
+    maintainers:
+      - name: The Falco Authors
+        email: cncf-falco-dev@lists.cncf.io
+


### PR DESCRIPTION
This PR adds the official Helm Chart Repository of the Falco project which has recently moved from `stable` to https://github.com/falcosecurity/charts