### PR TITLE
Add Gissilabs repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -516,3 +516,5 @@ sync:
       url: https://falcosecurity.github.io/charts
     - name: aerokube
       url: https://charts.aerokube.com/
+    - name: gissilabs
+      url: https://gissilabs.github.io/charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1463,3 +1463,8 @@ repositories:
     maintainers:
       - name: Aerokube Team
         email: support@aerokube.com
+  - name: gissilabs
+    url: https://gissilabs.github.io/charts/
+    maintainers:
+      - name: Silvio Gissi
+        email: silvio@gissilabs.com


### PR DESCRIPTION
Add Gissilabs repo. Already included in Artifact Hub (https://artifacthub.io/packages/search?page=1&repo=gissilabs).