### PR TITLE
Add Sonatype helm charts

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -8,6 +8,8 @@ sync:
   repos:
     # Helm hosted repositories
     - name: stable
+      url: https://sonatype.github.io/helm3-charts/
+    - name: stable
       url: https://kubernetes-charts.storage.googleapis.com
     - name: incubator
       url: https://kubernetes-charts-incubator.storage.googleapis.com

--- a/repos.yaml
+++ b/repos.yaml
@@ -14,6 +14,11 @@
 # because projects often have multiple people who may rotate on the team.
 repositories:
   - name: stable
+    url: https://sonatype.github.io/helm3-charts/
+    maintainers:
+      - name: Sonatype
+        email: ops@sonatype.com
+  - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
     maintainers:
       - name: Helm Project


### PR DESCRIPTION
New 'official' Sonatype helm charts for both the Nexus IQ Server and Nexus repository Manager