### PR TITLE
Fix name for sonatype repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -8,8 +8,6 @@ sync:
   repos:
     # Helm hosted repositories
     - name: stable
-      url: https://sonatype.github.io/helm3-charts/
-    - name: stable
       url: https://kubernetes-charts.storage.googleapis.com
     - name: incubator
       url: https://kubernetes-charts-incubator.storage.googleapis.com
@@ -518,3 +516,5 @@ sync:
       url: https://falcosecurity.github.io/charts
     - name: aerokube
       url: https://charts.aerokube.com/
+    - name: sonatype
+      url: https://sonatype.github.io/helm3-charts/

--- a/repos.yaml
+++ b/repos.yaml
@@ -14,11 +14,6 @@
 # because projects often have multiple people who may rotate on the team.
 repositories:
   - name: stable
-    url: https://sonatype.github.io/helm3-charts/
-    maintainers:
-      - name: Sonatype
-        email: ops@sonatype.com
-  - name: stable
     url: https://kubernetes-charts.storage.googleapis.com
     maintainers:
       - name: Helm Project
@@ -1468,3 +1463,8 @@ repositories:
     maintainers:
       - name: Aerokube Team
         email: support@aerokube.com
+  - name: sonatype
+    url: https://sonatype.github.io/helm3-charts/
+    maintainers:
+      - name: Sonatype
+        email: ops@sonatype.com


### PR DESCRIPTION
Having multiple "stable" repositories caused the first to be used so it was only sonatype charts available in https://hub.helm.sh/charts/stable