### PR TITLE
Add new Datadog Helm repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -528,5 +528,7 @@ sync:
       url: https://charts.balle-petersen.org/
     - name: storageos
       url: https://charts.storageos.com
+    - name: datadog
+      url: https://helm.datadoghq.com
     - name: w2bro
       url: https://radio-charts.w2bro.dev

--- a/repos.yaml
+++ b/repos.yaml
@@ -1493,6 +1493,11 @@ repositories:
     maintainers:
       - name: StorageOS
         email: support@storageos.com
+  - name: datadog
+    url: https://helm.datadoghq.com
+    maintainers:
+      - name: Datadog
+        email: support@datadoghq.com
   - name: w2bro
     url: https://radio-charts.w2bro.dev
     maintainers:


### PR DESCRIPTION
Adding new Datadog Helm repository.

**Note: ** Currently the `stable/datadog` repository is referenced in Helm Hub, what do you need to do to have the new repository replacing the old one? (Not to have the two in Helm Hub)