### PR TITLE
Add Neoskop charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -530,3 +530,5 @@ sync:
       url: https://charts.storageos.com
     - name: w2bro
       url: https://radio-charts.w2bro.dev
+    - name: neoskop
+      url: https://charts.neoskop.dev

--- a/repos.yaml
+++ b/repos.yaml
@@ -1498,3 +1498,10 @@ repositories:
     maintainers:
       - name: Ross McKelvie
         email: charts@w2b.ro
+  - name: neoskop
+    url: https://charts.neoskop.dev
+    maintainers:
+      - name: Arne Diekmann
+        email: diekmann@neoskop.de
+      - name: Neoskop
+        email: devops@neoskop.de


### PR DESCRIPTION
This adds my company's Helm repository with our open-source charts.