### PR TITLE
Add astarte Helm repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -530,3 +530,5 @@ sync:
       url: https://charts.storageos.com
     - name: w2bro
       url: https://radio-charts.w2bro.dev
+    - name: astarte
+      url: https://helm.astarte-platform.org

--- a/repos.yaml
+++ b/repos.yaml
@@ -1498,3 +1498,8 @@ repositories:
     maintainers:
       - name: Ross McKelvie
         email: charts@w2b.ro
+  - name: astarte
+    url: https://helm.astarte-platform.org
+    maintainers:
+      - name: Astarte Maintainers
+        email: maintainers@astarte-platform.org


### PR DESCRIPTION
This PR adds in the Astarte Helm Chart repository, which hosts the brand new chart for the [Astarte Operator](https://github.com/astarte-platform/astarte-kubernetes-operator). The chart is linted and released through Helm's Github Actions.