### PR TITLE
add minio repo for the deprecated/moved minio chart

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -530,3 +530,5 @@ sync:
       url: https://charts.storageos.com
     - name: w2bro
       url: https://radio-charts.w2bro.dev
+    - name: minio
+      url: https://helm.min.io/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1498,3 +1498,8 @@ repositories:
     maintainers:
       - name: Ross McKelvie
         email: charts@w2b.ro
+  - name: minio
+    url: https://helm.min.io/
+    maintainers:
+      - name: Minio
+        email: dev@minio.io


### PR DESCRIPTION
Minio has taken on ownership of their chart, this adds them to the helm hub

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>