### PR TITLE
Add Vertigo charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -530,3 +530,5 @@ sync:
       url: https://charts.storageos.com
     - name: w2bro
       url: https://radio-charts.w2bro.dev
+    - name: vertigo
+      url: https://vertigobr.github.io/vkpr

--- a/repos.yaml
+++ b/repos.yaml
@@ -1498,3 +1498,8 @@ repositories:
     maintainers:
       - name: Ross McKelvie
         email: charts@w2b.ro
+  - name: vertigo
+    url: https://vertigobr.github.io/vkpr
+    maintainers:
+      - name: Vertigo
+        email: devops@vertigo.com.br


### PR DESCRIPTION
Add Vertigo charts in Helm Hub.

Signed-off-by: Felipe Côrtes <lcortes@vertigo.com.br>