### PR TITLE
removing http://api.chartsm.com/ from repos.yaml : dns does not exist.

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -764,11 +764,6 @@ repositories:
     maintainers:
       - email: charlie+helm@charliedrage.com
         name: Charlie Drage
-  - name: chartsm
-    url: https://api.chartsm.com
-    maintainers:
-      - email: arnaud@deviarch.be
-        name: Arnaud De Backer
   - name: fold
     url: https://charts.foldapp.com
     maintainers:


### PR DESCRIPTION
Hi,
For the sanity of config data, is it possible to remove this entry from repos.yaml?
Validated by https://dnschecker.org/#A/api.chartsm.com not finding this domain name as valid.
Thanks!
Didier