### PR TITLE
removing http://api.chartsm.com/ from repos.yaml : dns does not exist.

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -272,8 +272,6 @@ sync:
       url: https://backube.github.io/helm-charts/
     - name: k8s-land
       url: https://charts.k8s.land
-    - name: chartsm
-      url: https://api.chartsm.com
     - name: fold
       url: https://charts.foldapp.com
     - name: vmware-tanzu

--- a/repos.yaml
+++ b/repos.yaml
@@ -764,11 +764,6 @@ repositories:
     maintainers:
       - email: charlie+helm@charliedrage.com
         name: Charlie Drage
-  - name: chartsm
-    url: https://api.chartsm.com
-    maintainers:
-      - email: arnaud@deviarch.be
-        name: Arnaud De Backer
   - name: fold
     url: https://charts.foldapp.com
     maintainers:


### PR DESCRIPTION
Hi,
For the sanity of config data, is it possible to remove this entry from repos.yaml?
Validated by https://dnschecker.org/#A/api.chartsm.com not finding this domain name as valid.
Thanks!
Didier

Signed-off-by: didier <durand.didier@gmail.com>