### PR TITLE
Add QuestDB to Helm Hub

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -560,3 +560,5 @@ sync:
       url: https://kubernetes.github.io/ingress-nginx
     - name: lakefs
       url: https://charts.lakefs.io
+    - name: questdb
+      url: https://helm.questdb.io

--- a/repos.yaml
+++ b/repos.yaml
@@ -1581,3 +1581,8 @@ repositories:
     maintainers:
       - name: Treeverse
         email: support@treeverse.io
+  - name: questdb
+    url: https://helm.questdb.io
+    maintainers:
+      - name: QuestDB Team
+        email: containers@questdb.io


### PR DESCRIPTION
Hi Helm team,
This PR adds QuestDB's Helm repository to Hub. The repository contains currently 1 chart, "questdb".
The chart sources can be found on [GitHub](https://github.com/questdb/questdb-kubernetes).
Thanks you.