### PR TITLE
Add kvaps repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -560,3 +560,5 @@ sync:
       url: https://kubernetes.github.io/ingress-nginx
     - name: lakefs
       url: https://charts.lakefs.io
+    - name: kvaps
+      url: https://kvaps.github.io/charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -1581,3 +1581,8 @@ repositories:
     maintainers:
       - name: Treeverse
         email: support@treeverse.io
+  - name: kvaps
+    url: https://kvaps.github.io/charts
+    maintainers:
+      - name: Andrei Kvapil
+        email: kvapss@gmail.com


### PR DESCRIPTION
Repo conains:

- [kubernetes](https://github.com/kvaps/kubernetes-in-kubernetes)
- [opennebula](https://github.com/kvaps/kube-opennebula)
- [linstor](https://github.com/kvaps/kube-linstor)

*... and many other useful charts*

I also going to take few charts from stable on maintenance:
- [stolon](https://github.com/kvaps/stolon-chart)
- [nfs-server-provisioner](https://github.com/kvaps/nfs-server-provisioner-chart)

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>