### PR TITLE
Add portainer helm chart repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -560,3 +560,5 @@ sync:
       url: https://kubernetes.github.io/ingress-nginx
     - name: lakefs
       url: https://charts.lakefs.io
+    - name: portainer
+      url: https://portainer.github.io/k8s/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1581,3 +1581,8 @@ repositories:
     maintainers:
       - name: Treeverse
         email: support@treeverse.io
+  - name: portainer
+    url: https://portainer.github.io/k8s/
+    maintainers:
+      - name: funkypenguin
+        email: davidy@funkypenguin.co.nz


### PR DESCRIPTION
Hey guys,

I'm working with the Portainer.io team on their new K8s support, and imminent v2.0.0 release. This PR adds the helm charts which originate from their GitHub repo. To validate that I have permission to do this, observe who made all the commits to the portainer-owned repo ;)

The repo is passing ct linting, and releases are done using cr.

Cheers!
D