### PR TITLE
Add jenkinsci helm charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -240,6 +240,8 @@ sync:
       url: https://cgroschupp.github.io/helm-charts/
     - name: jenkins
       url: https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart
+    - name: jenkinsci
+      url: https://charts.jenkins.io/
     - name: talend
       url: https://talend.github.io/helm-charts-public/stable
     - name: softonic

--- a/repos.yaml
+++ b/repos.yaml
@@ -658,6 +658,11 @@ repositories:
         name: Tomasz Sęk
       - email: jal-khalili@virtuslab.com
         name: Jakub Al-Khalili
+  - name: jenkinsci
+    url: https://charts.jenkins.io/
+    maintainers:
+      - email: mail@torstenwalter.de
+        name: Torsten Walter
   - name: talend
     url: https://talend.github.io/helm-charts-public/stable
     maintainers:


### PR DESCRIPTION
`stable/jenkins` chart moved to https://charts.jenkins.io/

Part-of: jenkinsci/helm-charts#5
