### PR TITLE
Fixing prometheus community repo name

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -574,5 +574,5 @@ sync:
       url: https://lightstep.github.io/lightstep-satellite-helm-chart/
     - name: fasterbytes
       url: https://fasterbytes.github.io/charts
-    - name: prometheus-community
+    - name: prometheus-com
       url: https://prometheus-community.github.io/helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -1615,7 +1615,7 @@ repositories:
     maintainers:
       - name: John Teague
         email: john@fasterbytes.com
-  - name: prometheus-community
+  - name: prometheus-com
     url: https://prometheus-community.github.io/helm-charts
     maintainers:
       - email: scott@r6by.com


### PR DESCRIPTION
The prometheus community repo name generated a cronjob with a
name that is too long by 2 characters. This shortens up the name
so the cronjob can be created.

Note, this issue has been improved in upstream monocular. It will
not be fixed in the Helm Hub as we are deprecating the Helm Hub.