### PR TITLE
add drycc repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -576,3 +576,5 @@ sync:
       url: https://fasterbytes.github.io/charts
     - name: prometheus-com
       url: https://prometheus-community.github.io/helm-charts
+    - name: drycc
+      url: https://charts.drycc.cc/stable

--- a/repos.yaml
+++ b/repos.yaml
@@ -1620,3 +1620,8 @@ repositories:
     maintainers:
       - email: scott@r6by.com
         name: scottrigby
+  - name: drycc
+    url: https://charts.drycc.cc/stable
+    maintainers:
+      - email: duanhongyi@drycc.cc
+        name: duanhongyi


### PR DESCRIPTION
Maintainer of drycc Workflow charts (https://github.com/drycc) here. We would like to be a part of the Helm Hub. Our main charts repo is charts.drycc.cc/stable .