### PR TITLE
Add LogicMonitor helm charts repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -576,3 +576,5 @@ sync:
       url: https://fasterbytes.github.io/charts
     - name: prometheus-com
       url: https://prometheus-community.github.io/helm-charts
+    - name: logicmonitor
+      url: https://logicmonitor.github.com/k8s-helm-charts

--- a/repos.yaml
+++ b/repos.yaml
@@ -1620,3 +1620,12 @@ repositories:
     maintainers:
       - email: scott@r6by.com
         name: scottrigby
+  - name: logicmonitor
+    url: https://logicmonitor.github.com/k8s-helm-charts
+    maintainers:
+      - email: argus@logicmonitor.com
+        name: LogicMonitor
+      - email: vaibhav.kumbhar@logicmonitor.com
+        name: Vaibhav Kumbhar
+      - email: vkumbhar94@gmail.com
+        name: Vaibhav Kumbhar


### PR DESCRIPTION
Signed-off-by: vkumbhar94 <vkumbhar94@gmail.com>
I, Vaibhav Kumbhar, am a member of LogicMonitor Github organisation. On behalf of LogicMonitor org., I would like to list LogicMonitor's helm charts on helm hub.
More about LogicMonitor: https://www.logicmonitor.com