### PR TITLE
Update Percona Helm repo info

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -553,7 +553,7 @@ sync:
     - name: descheduler
       url: https://kubernetes-sigs.github.io/descheduler/
     - name: percona
-      url: https://percona-lab.github.io/percona-helm-charts/
+      url: https://percona.github.io/percona-helm-charts/
     - name: kuma
       url: https://kumahq.github.io/charts
     - name: anchore

--- a/repos.yaml
+++ b/repos.yaml
@@ -1555,10 +1555,10 @@ repositories:
       - name: Kubernetes SIG Scheduling
         email: kubernetes-sig-scheduling@googlegroups.com
   - name: percona
-    url: https://percona-lab.github.io/percona-helm-charts/
+    url: https://percona.github.io/percona-helm-charts/
     maintainers:
-      - name: Ivan Pylypenko
-        email: ivan.pylypenko@percona.com
+      - name: EngCloud
+        email: eng-cloud@percona.com
   - name: kuma
     url: https://kumahq.github.io/charts
     maintainers:


### PR DESCRIPTION
Hi,

Percona repository https://percona-lab.github.io/percona-helm-charts/ has moved to https://percona.github.io/percona-helm-charts/
so we would like to update this and also switch to using a team mailing list for contact instead of single person email.

Thanks!