### PR TITLE
Add Mongoose charts

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -578,3 +578,5 @@ sync:
       url: https://prometheus-community.github.io/helm-charts
     - name: drycc
       url: https://charts.drycc.cc/stable
+    - name: mongoosehelm
+      url: https://esl.github.io/MongooseHelm/

--- a/repos.yaml
+++ b/repos.yaml
@@ -1625,3 +1625,8 @@ repositories:
     maintainers:
       - email: duanhongyi@drycc.cc
         name: duanhongyi
+  - name: mongoosehelm
+    url: https://esl.github.io/MongooseHelm/
+    maintainers:
+      - name: MongooseIM Team
+        email: mongooseim@erlang-solutions.com


### PR DESCRIPTION
Our repository with all the chart definitions is hosted here: https://github.com/esl/MongooseHelm. Readmes will be updated, but a pipeline to lint every single push to github and to automate adding new chart versions is hosted in CircleCI. Github pages serves an orphan commit containing only the `.tgz` packages and the `index.yaml`.

Let me know if there's anything that should be improved. Looking forward to see this merged 😄 