### PR TITLE
add keyporttech repo

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -578,3 +578,6 @@ sync:
       url: https://prometheus-community.github.io/helm-charts
     - name: drycc
       url: https://charts.drycc.cc/stable
+    - name: keyporttech
+      url: https://keyporttech.github.io/helm-charts/
+    

--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -579,5 +579,5 @@ sync:
     - name: drycc
       url: https://charts.drycc.cc/stable
     - name: keyporttech
-      url: https://keyporttech.github.io/helm-charts/
+      url: https://keyporttech.github.io/helm-charts
     

--- a/repos.yaml
+++ b/repos.yaml
@@ -1625,3 +1625,10 @@ repositories:
     maintainers:
       - email: duanhongyi@drycc.cc
         name: duanhongyi
+  - name: keyporttech
+    url: https://keyporttech.github.io/helm-charts/
+    maintainers:
+      - email: admin@keyporttech.com 
+        name: jfelten
+      - email: admin@keyporttech.com 
+        name: peter-lamanna


### PR DESCRIPTION
Adds the keyporttech repos. We do cicd using the chart-testing and chart-releaser tools, and I am happy to address any changes that might be required.