### PR TITLE
Add GoCD Helm Chart Repository

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -578,3 +578,5 @@ sync:
       url: https://prometheus-community.github.io/helm-charts
     - name: drycc
       url: https://charts.drycc.cc/stable
+    - name: gocd
+      url: https://gocd.github.io/helm-chart

--- a/repos.yaml
+++ b/repos.yaml
@@ -1625,3 +1625,16 @@ repositories:
     maintainers:
       - email: duanhongyi@drycc.cc
         name: duanhongyi
+  - name: gocd
+    url: https://gocd.github.io/helm-chart
+    maintainers:
+      - name: Aravind SV
+        email: avenkata@thoughtworks.com
+      - name: Ganesh Patil
+        email: ganeshpl@thoughtworks.com
+      - name: Kritika Singh
+        email: kritika.singh@thoughtworks.com
+      - name: Mahesh Panchaksharaiah
+        email: maheshp@thoughtworks.com
+      - name: Marques Lee
+        email: malee@thoughtworks.com


### PR DESCRIPTION
With upcoming deprecation of `helm/charts` repository,  the stable/gocd helm chart from `helm/charts` will be deprecated in favor of this GoCD's [Official Helm Chart](https://github.com/gocd/helm-chart).

Signed-off-by: GaneshSPatil <ganeshpl@thoughtworks.com>