### PR TITLE
Jetstack finally packages crds, we no longer need a fork

### DIFF
--- a/config/repo-values.yaml
+++ b/config/repo-values.yaml
@@ -43,8 +43,6 @@ sync:
       url: https://charts.jetstack.io
     - name: ibm-charts
       url: https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
-    - name: infobloxopen
-      url: https://infobloxopen.github.io/cert-manager/
     - name: kanister
       url: https://charts.kanister.io/
     - name: fikaworks

--- a/repos.yaml
+++ b/repos.yaml
@@ -118,11 +118,6 @@ repositories:
     maintainers:
       - email: icp@ibm.com
         name: IBM Cloud Private
-  - name: infobloxopen
-    url: https://infobloxopen.github.io/cert-manager/
-    maintainers:
-      - email: dwells@infoblox.com
-        name: Drew Wells
   - name: kanister
     url: https://charts.kanister.io/
     maintainers:


### PR DESCRIPTION
We're deprecating our helm repo because jetstack fixed the issues with its helm chart.