### PR TITLE
Repo deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- markdownlint-disable MD041 -->
+|![Warning](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | This project is no longer supported. [hub.helm.sh](https://hub.helm.sh) now redirects to [artifacthub.io](https://artifacthub.io/). The source for that can be found at <https://github.com/artifacthub/hub>
+|---|---|
+
 # Helm Hub
 
 The Helm Hub repository contained the documentation and some configuration for the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The Helm Hub repository contained the documentation and some configuration for the
 distributed public repository search hosted by Helm that used to be found at https://hub.helm.sh
 
-## ⚠️ NOTICE: Redirect To Artifact Hub
+## Redirect To Artifact Hub
 
 The [Artifact Hub](https://artifacthub.io/) is a CNCF project to make discovering
 distributed cloud native artifacts easy. This includes Helm charts. The Helm Hub,


### PR DESCRIPTION
Deprecation notice for #439

I have already updated the repo "about" and "website" info:
>⚠️(OBSOLETE) Former distributed charts search for hub.helm.sh. Now see https://artifacthub.io/

Once this PR is merged, and we close #439, we can archive the repo in GItHub.